### PR TITLE
Add DevContainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "py-key-value",
+  "image": "ghcr.io/astral-sh/uv:python3.10-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "DavidAnson.vscode-markdownlint"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestArgs": [
+          "key-value",
+          "--import-mode=importlib",
+          "-vv"
+        ]
+      }
+    }
+  },
+  "postCreateCommand": "make sync",
+  "remoteUser": "root"
+}


### PR DESCRIPTION
This PR adds a DevContainer configuration to enable consistent, containerized development environments for contributors.

### Changes

- Created `.devcontainer/devcontainer.json` with uv-based Python 3.10 environment
- Uses official `ghcr.io/astral-sh/uv:python3.10-bookworm` Docker image
- Configured Node.js LTS for markdown linting
- Pre-configured VSCode extensions: Python, Pylance, Ruff, markdownlint
- Uses `make sync` for automatic dependency installation
- Mirrors pytest configuration from existing `.vscode/settings.json`

### Benefits

- Consistent development environment across all contributors
- Eliminates "works on my machine" issues
- Mirrors CI/CD pipeline configuration
- Easy onboarding for new contributors
- Integrates with merged Makefile commands

Fixes #100

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development container configuration with Python and Node.js support, including pre-configured VSCode extensions and test settings for streamlined developer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->