### PR TITLE
feat: improve AIO adapter test coverage and documentation

### DIFF
--- a/key-value/key-value-aio/src/key_value/aio/adapters/pydantic/adapter.py
+++ b/key-value/key-value-aio/src/key_value/aio/adapters/pydantic/adapter.py
@@ -91,6 +91,10 @@ class PydanticAdapter(Generic[T]):
         Raises:
             DeserializationError if the stored data cannot be validated as the model and the PydanticAdapter is configured to
             raise on validation error.
+
+        Note:
+            When raise_on_validation_error=False and validation fails, returns the default value (which may be None).
+            When raise_on_validation_error=True and validation fails, raises DeserializationError.
         """
         collection = collection or self._default_collection
 
@@ -121,6 +125,11 @@ class PydanticAdapter(Generic[T]):
         Raises:
             DeserializationError if the stored data cannot be validated as the model and the PydanticAdapter is configured to
             raise on validation error.
+
+        Note:
+            When raise_on_validation_error=False and validation fails for any key, that position in the returned list
+            will contain the default value (which may be None). The method returns a complete list matching the order
+            and length of the input keys, with defaults substituted for missing or invalid entries.
         """
         collection = collection or self._default_collection
 
@@ -171,7 +180,16 @@ class PydanticAdapter(Generic[T]):
     async def ttl(self, key: str, *, collection: str | None = None) -> tuple[T | None, float | None]:
         """Get a model and its TTL seconds if present.
 
-        Returns (model, ttl_seconds) or (None, None) if missing.
+        Args:
+            key: The key to retrieve.
+            collection: The collection to use. If not provided, uses the default collection.
+
+        Returns:
+            A tuple of (model, ttl_seconds). Returns (None, None) if the key is missing or validation fails.
+
+        Note:
+            When validation fails and raise_on_validation_error=False, returns (None, None) even if TTL data exists.
+            When validation fails and raise_on_validation_error=True, raises DeserializationError.
         """
         collection = collection or self._default_collection
 

--- a/key-value/key-value-aio/tests/adapters/test_raise.py
+++ b/key-value/key-value-aio/tests/adapters/test_raise.py
@@ -35,3 +35,31 @@ async def test_get_many_missing(adapter: RaiseOnMissingAdapter):
     await adapter.put(collection="test", key="test", value={"test": "test"})
     with pytest.raises(MissingKeyError):
         _ = await adapter.get_many(collection="test", keys=["test", "test_2"], raise_on_missing=True)
+
+
+async def test_ttl(adapter: RaiseOnMissingAdapter):
+    await adapter.put(collection="test", key="test", value={"test": "test"}, ttl=60)
+    value, ttl = await adapter.ttl(collection="test", key="test")
+    assert value == {"test": "test"}
+    assert ttl is not None
+
+
+async def test_ttl_missing(adapter: RaiseOnMissingAdapter):
+    with pytest.raises(MissingKeyError):
+        _ = await adapter.ttl(collection="test", key="test", raise_on_missing=True)
+
+
+async def test_ttl_many(adapter: RaiseOnMissingAdapter):
+    await adapter.put(collection="test", key="test", value={"test": "test"}, ttl=60)
+    await adapter.put(collection="test", key="test_2", value={"test": "test_2"}, ttl=120)
+    results = await adapter.ttl_many(collection="test", keys=["test", "test_2"])
+    assert results[0][0] == {"test": "test"}
+    assert results[0][1] is not None
+    assert results[1][0] == {"test": "test_2"}
+    assert results[1][1] is not None
+
+
+async def test_ttl_many_missing(adapter: RaiseOnMissingAdapter):
+    await adapter.put(collection="test", key="test", value={"test": "test"}, ttl=60)
+    with pytest.raises(MissingKeyError):
+        _ = await adapter.ttl_many(collection="test", keys=["test", "test_2"], raise_on_missing=True)


### PR DESCRIPTION
## Summary

Implements the recommended improvements from the in-depth AIO adapters code review for the 0.3.0 release.

### Changes
- Add test coverage for RaiseOnMissingAdapter ttl and ttl_many methods
- Enhance PydanticAdapter docstrings to document edge case behavior
- Document validation error handling with raise_on_validation_error flag

### Verification
- ✅ All adapter tests passing (14/14)
- ✅ Python linting passes (Ruff)
- ✅ Type checking passes on modified files (basedpyright strict)

Closes #138

---

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/strawgate/py-key-value/actions/runs/18826178583) | [View branch](https://github.com/strawgate/py-key-value/tree/claude/issue-138-20251027-0034