### PR TITLE
Enhance docstrings across key-value-aio codebase

### DIFF
--- a/key-value/key-value-aio/src/key_value/aio/protocols/key_value.py
+++ b/key-value/key-value-aio/src/key_value/aio/protocols/key_value.py
@@ -4,7 +4,12 @@ from typing import Any, Protocol, SupportsFloat, runtime_checkable
 
 @runtime_checkable
 class AsyncKeyValueProtocol(Protocol):
-    """A subset of KV operations: get/put/delete and TTL variants, including bulk calls."""
+    """A subset of KV operations: get/put/delete and TTL variants, including bulk calls.
+
+    This protocol defines the minimal contract for key-value store implementations. All methods are
+    async and may raise exceptions on connection failures, validation errors, or other operational issues.
+    Implementations should handle backend-specific errors appropriately.
+    """
 
     async def get(
         self,
@@ -54,6 +59,9 @@ class AsyncKeyValueProtocol(Protocol):
         Args:
             key: The key to delete the value from.
             collection: The collection to delete the value from. If no collection is provided, it will use the default collection.
+
+        Returns:
+            True if the key was deleted, False if the key did not exist.
         """
         ...
 

--- a/key-value/key-value-aio/src/key_value/aio/stores/base.py
+++ b/key-value/key-value-aio/src/key_value/aio/stores/base.py
@@ -32,6 +32,18 @@ DEFAULT_SEED_DATA: FROZEN_SEED_DATA_TYPE = MappingProxyType({})
 
 
 def _seed_to_frozen_seed_data(seed: SEED_DATA_TYPE) -> FROZEN_SEED_DATA_TYPE:
+    """Convert mutable seed data to an immutable frozen structure.
+
+    This function converts the nested mapping structure of seed data into immutable MappingProxyType
+    objects at all levels. Using immutable structures prevents accidental modification of seed data
+    after store initialization and ensures thread-safety.
+
+    Args:
+        seed: The mutable seed data mapping: {collection: {key: {field: value}}}.
+
+    Returns:
+        An immutable frozen version of the seed data using MappingProxyType.
+    """
     return MappingProxyType(
         {collection: MappingProxyType({key: MappingProxyType(value) for key, value in items.items()}) for collection, items in seed.items()}
     )
@@ -101,6 +113,15 @@ class BaseStore(AsyncKeyValueProtocol, ABC):
                 await self.put(key=key, value=dict(value), collection=collection)
 
     async def setup(self) -> None:
+        """Initialize the store if not already initialized.
+
+        This method is called automatically before any store operations and uses a lock to ensure
+        thread-safe lazy initialization. It can also be called manually to ensure the store is ready
+        before performing operations. The setup process includes calling the `_setup()` hook and
+        seeding the store with initial data if provided.
+
+        This method is idempotent - calling it multiple times has no additional effect after the first call.
+        """
         if not self._setup_complete:
             async with self._setup_lock:
                 if not self._setup_complete:
@@ -116,6 +137,19 @@ class BaseStore(AsyncKeyValueProtocol, ABC):
                     await self._seed_store()
 
     async def setup_collection(self, *, collection: str) -> None:
+        """Initialize a specific collection if not already initialized.
+
+        This method is called automatically before any collection-specific operations and uses a per-collection
+        lock to ensure thread-safe lazy initialization. It can also be called manually to ensure a collection
+        is ready before performing operations on it. The setup process includes calling the `_setup_collection()`
+        hook for store-specific collection initialization.
+
+        This method is idempotent - calling it multiple times for the same collection has no additional effect
+        after the first call.
+
+        Args:
+            collection: The name of the collection to initialize.
+        """
         await self.setup()
 
         if not self._setup_collection_complete[collection]:

--- a/key-value/key-value-aio/src/key_value/aio/stores/redis/store.py
+++ b/key-value/key-value-aio/src/key_value/aio/stores/redis/store.py
@@ -21,15 +21,32 @@ PAGE_LIMIT = 10000
 
 
 def managed_entry_to_json(managed_entry: ManagedEntry) -> str:
-    """
-    Convert a ManagedEntry to a JSON string.
+    """Convert a ManagedEntry to a JSON string for Redis storage.
+
+    This function serializes a ManagedEntry to JSON format including all metadata (TTL, creation,
+    and expiration timestamps). The serialization is designed to preserve all entry information
+    for round-trip conversion back to a ManagedEntry.
+
+    Args:
+        managed_entry: The ManagedEntry to serialize.
+
+    Returns:
+        A JSON string representation of the ManagedEntry with full metadata.
     """
     return managed_entry.to_json(include_metadata=True, include_expiration=True, include_creation=True)
 
 
 def json_to_managed_entry(json_str: str) -> ManagedEntry:
-    """
-    Convert a JSON string to a ManagedEntry.
+    """Convert a JSON string from Redis storage back to a ManagedEntry.
+
+    This function deserializes a JSON string (created by `managed_entry_to_json`) back to a
+    ManagedEntry object, preserving all metadata including TTL, creation, and expiration timestamps.
+
+    Args:
+        json_str: The JSON string to deserialize.
+
+    Returns:
+        A ManagedEntry object reconstructed from the JSON string.
     """
     return ManagedEntry.from_json(json_str=json_str, includes_metadata=True)
 

--- a/key-value/key-value-aio/src/key_value/aio/wrappers/base.py
+++ b/key-value/key-value-aio/src/key_value/aio/wrappers/base.py
@@ -8,7 +8,24 @@ from key_value.aio.protocols.key_value import AsyncKeyValue
 
 
 class BaseWrapper(AsyncKeyValue):
-    """A base wrapper for KVStore implementations that passes through to the underlying store."""
+    """A base wrapper for KVStore implementations that passes through to the underlying store.
+
+    This class implements the passthrough pattern where all operations are delegated to the wrapped
+    key-value store without modification. It serves as a foundation for creating custom wrappers that
+    need to intercept, modify, or enhance specific operations while passing through others unchanged.
+
+    To create a custom wrapper, subclass this class and override only the methods you need to customize.
+    All other operations will automatically pass through to the underlying store.
+
+    Example:
+        class LoggingWrapper(BaseWrapper):
+            async def get(self, key: str, *, collection: str | None = None):
+                logger.info(f"Getting key: {key}")
+                return await super().get(key, collection=collection)
+
+    Attributes:
+        key_value: The underlying AsyncKeyValue store that operations are delegated to.
+    """
 
     key_value: AsyncKeyValue
 


### PR DESCRIPTION
## Summary

This PR implements comprehensive docstring improvements across the async key-value library, addressing all priority levels from the docstring review in issue #135.

## Changes

### Priority 1 (High Impact)
- Add Returns documentation to `AsyncKeyValueProtocol.delete` method
- Document `setup()` and `setup_collection()` methods in BaseStore with details on lazy initialization, thread-safety, and idempotency
- Expand `BaseWrapper` class docstring with passthrough pattern explanation and usage example

### Priority 2 (Medium Impact)
- Add detailed docstrings to helper functions in RedisStore (`managed_entry_to_json`, `json_to_managed_entry`)
- Add detailed docstrings to helper functions in MongoDBStore (`document_to_managed_entry`, `managed_entry_to_document`, `_sanitize_collection_name`)
- Enhance `AsyncKeyValueProtocol` class docstring to document exception behavior

### Priority 3 (Nice-to-have)
- Add docstring to `_seed_to_frozen_seed_data` explaining immutability rationale
- Enhance PydanticAdapter internal method docstrings (`_validate_model`, `_serialize_model`) with list model wrapping convention details

## Quality Assurance
- ✅ Linting passed - All files properly formatted
- ✅ Follows Google-style docstring format consistently
- ✅ Maintains existing documentation conventions
- ✅ Ready for automated documentation generation with mkdocstrings

Closes #135

----

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced docstrings and clarified behavior for store initialization, async protocols, serialization/deserialization, and error handling across the key-value store implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->