### PR TITLE
fix: add .html extensions to documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This monorepo contains two libraries:
 ## Documentation
 
 - [Full Documentation](https://strawgate.com/py-key-value/)
-- [Getting Started Guide](https://strawgate.com/py-key-value/getting-started/)
-- [Wrappers Guide](https://strawgate.com/py-key-value/wrappers/)
-- [Adapters Guide](https://strawgate.com/py-key-value/adapters/)
-- [API Reference](https://strawgate.com/py-key-value/api/protocols/)
+- [Getting Started Guide](https://strawgate.com/py-key-value/getting-started.html)
+- [Wrappers Guide](https://strawgate.com/py-key-value/wrappers.html)
+- [Adapters Guide](https://strawgate.com/py-key-value/adapters.html)
+- [API Reference](https://strawgate.com/py-key-value/api/protocols.html)
 
 ## Why use this library?
 
@@ -354,7 +354,7 @@ library.
 ## Project links
 
 - [Full Documentation](https://strawgate.com/py-key-value/)
-- [API Reference](https://strawgate.com/py-key-value/api/protocols/)
+- [API Reference](https://strawgate.com/py-key-value/api/protocols.html)
 
 Contributions welcome but may not be accepted. File an issue before submitting
 a pull request. If you do not get agreement on your proposal before making a


### PR DESCRIPTION
Fixes broken documentation links in README.md that were pointing to directory-style URLs without .html extensions. The MkDocs site requires .html extensions for all documentation pages.

## Changes
- Getting Started Guide: `getting-started/` → `getting-started.html`
- Wrappers Guide: `wrappers/` → `wrappers.html`
- Adapters Guide: `adapters/` → `adapters.html`
- API Reference (2 locations): `api/protocols/` → `api/protocols.html`

Fixes #182

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to HTML pages for Getting Started, Wrappers, Adapters, and API Reference sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->