### PR TITLE
docs: add missing Stores Guide links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This monorepo contains two libraries:
 
 - [Full Documentation](https://strawgate.com/py-key-value/)
 - [Getting Started Guide](https://strawgate.com/py-key-value/getting-started.html)
+- [Stores Guide](https://strawgate.com/py-key-value/stores.html)
 - [Wrappers Guide](https://strawgate.com/py-key-value/wrappers.html)
 - [Adapters Guide](https://strawgate.com/py-key-value/adapters.html)
 - [API Reference](https://strawgate.com/py-key-value/api/protocols.html)
@@ -196,7 +197,7 @@ Each store has a **stability rating** indicating likelihood of
 backwards-incompatible changes. Stable stores (Redis, Valkey, Disk, Keyring)
 are recommended for long-term storage.
 
-**[📚 View all stores, installation guides, and examples →](https://strawgate.com/py-key-value/stores/)**
+**[📚 View all stores, installation guides, and examples →](https://strawgate.com/py-key-value/stores.html)**
 
 ### Adapters
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ py-key-value is a Python framework that offers:
 ## Quick Links
 
 - [Getting Started](getting-started.md) - Installation and basic usage
+- [Stores](stores.md) - Detailed documentation for all stores
 - [Wrappers](wrappers.md) - Detailed documentation for all wrappers
 - [Adapters](adapters.md) - Detailed documentation for all adapters
 - [API Reference](api/protocols.md) - Complete API documentation


### PR DESCRIPTION
Fixes the missing documentation links identified in issue #189.

## Changes

- Add Stores Guide link to README.md documentation section
- Fix trailing slash in stores link (stores/ -> stores.html)
- Add Stores link to docs/index.md Quick Links section

The stores.md file exists and is referenced in mkdocs.yml, but was missing from the main documentation navigation in both README.md and docs/index.md.

Fixes #189

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Stores Guide to quick navigation resources for improved discoverability of store information.
  * Updated store navigation links for consistent routing across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->