### PR TITLE
Add make test-concise for AI-friendly test output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ make precommit
 ### Testing Requirements
 
 - All new features require tests in both async and sync packages
-- Run `make test` to execute all test suites
+- Run `make test` to execute all test suites (verbose output)
+- Run `make test-concise` for minimal output (recommended for AI agents)
 - Run `make test-aio` for async package tests only
 - Run `make test-sync` for sync package tests only
 - Test coverage should be maintained
@@ -253,10 +254,14 @@ type annotation issues to maintain type safety guarantees.
 | `make install` | Alias for `make sync` |
 | `make lint` | Lint Python + Markdown |
 | `make typecheck` | Run Basedpyright type checking |
-| `make test` | Run all test suites |
+| `make test` | Run all test suites (verbose) |
+| `make test-concise` | Run all test suites (concise output for AI) |
 | `make test-aio` | Run async package tests |
+| `make test-aio-concise` | Run async package tests (concise) |
 | `make test-sync` | Run sync package tests |
+| `make test-sync-concise` | Run sync package tests (concise) |
 | `make test-shared` | Run shared package tests |
+| `make test-shared-concise` | Run shared package tests (concise) |
 | `make codegen` | Generate sync library from async |
 | `make precommit` | Run lint + typecheck + codegen |
 | `make build` | Build all packages |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: bump-version bump-version-dry codegen lint typecheck sync precommit test build help
-.PHONY: install test-aio test-sync test-shared docs-serve docs-build docs-deploy
+.PHONY: install test-aio test-sync test-shared test-concise test-aio-concise test-sync-concise test-shared-concise docs-serve docs-build docs-deploy
 
 # Default target - show help
 .DEFAULT_GOAL := help
@@ -12,10 +12,14 @@ help:
 	@echo "  make install           - Alias for sync"
 	@echo "  make lint              - Run linters (Python + Markdown)"
 	@echo "  make typecheck         - Run type checking"
-	@echo "  make test              - Run all tests"
+	@echo "  make test              - Run all tests (verbose)"
+	@echo "  make test-concise      - Run all tests (concise output for AI agents)"
 	@echo "  make test-aio          - Run async package tests"
+	@echo "  make test-aio-concise  - Run async package tests (concise)"
 	@echo "  make test-sync         - Run sync package tests"
+	@echo "  make test-sync-concise - Run sync package tests (concise)"
 	@echo "  make test-shared       - Run shared package tests"
+	@echo "  make test-shared-concise - Run shared package tests (concise)"
 	@echo "  make build             - Build all packages"
 	@echo "  make codegen           - Generate sync package from async"
 	@echo "  make precommit         - Run pre-commit checks (lint + typecheck + codegen)"
@@ -109,6 +113,31 @@ test-sync:
 test-shared:
 	@echo "Testing key-value-shared..."
 	@uv run pytest key-value/key-value-shared/tests -vv
+
+# Concise test output for AI agents - supports PROJECT parameter
+test-concise:
+ifdef PROJECT
+	@echo "Testing $(PROJECT) (concise output)..."
+	@cd $(PROJECT) && uv run pytest tests . -qq --tb=line --no-header
+else
+	@echo "Testing all packages (concise output)..."
+	@uv run pytest key-value/key-value-aio/tests -qq --tb=line --no-header
+	@uv run pytest key-value/key-value-sync/tests -qq --tb=line --no-header
+	@uv run pytest key-value/key-value-shared/tests -qq --tb=line --no-header
+endif
+
+# Convenience targets for specific packages with concise output
+test-aio-concise:
+	@echo "Testing key-value-aio (concise output)..."
+	@uv run pytest key-value/key-value-aio/tests -qq --tb=line --no-header
+
+test-sync-concise:
+	@echo "Testing key-value-sync (concise output)..."
+	@uv run pytest key-value/key-value-sync/tests -qq --tb=line --no-header
+
+test-shared-concise:
+	@echo "Testing key-value-shared (concise output)..."
+	@uv run pytest key-value/key-value-shared/tests -qq --tb=line --no-header
 
 # Build target - supports PROJECT parameter
 build:


### PR DESCRIPTION
## Summary

Adds new `make test-concise` targets that produce minimal, AI-friendly test output using pytest's `-qq --tb=line --no-header` flags.

## Changes

- ✅ Added `test-concise` target to Makefile with PROJECT parameter support
- ✅ Added convenience targets: `test-aio-concise`, `test-sync-concise`, `test-shared-concise`
- ✅ Updated `.PHONY` declarations
- ✅ Updated help message in Makefile
- ✅ Updated AGENTS.md documentation

## Benefits

- Dramatically reduces test output verbosity for AI agents
- Shows dots for passing tests instead of full test names
- Only displays one-line summaries for failures
- Reduces output from thousands of lines to just a few

Closes #226

---

Generated with [Claude Code](https://claude.ai/code)