### PR TITLE
fix: Extract username from Redis URL for ACL authentication

### DIFF
--- a/key-value/key-value-aio/src/key_value/aio/stores/redis/store.py
+++ b/key-value/key-value-aio/src/key_value/aio/stores/redis/store.py
@@ -74,6 +74,7 @@ class RedisStore(BaseDestroyStore, BaseEnumerateKeysStore, BaseContextManagerSto
                 host=parsed_url.hostname or "localhost",
                 port=parsed_url.port or 6379,
                 db=int(parsed_url.path.lstrip("/")) if parsed_url.path and parsed_url.path != "/" else 0,
+                username=parsed_url.username,
                 password=parsed_url.password or password,
                 decode_responses=True,
             )

--- a/key-value/key-value-sync/src/key_value/sync/code_gen/stores/redis/store.py
+++ b/key-value/key-value-sync/src/key_value/sync/code_gen/stores/redis/store.py
@@ -77,6 +77,7 @@ class RedisStore(BaseDestroyStore, BaseEnumerateKeysStore, BaseContextManagerSto
                 host=parsed_url.hostname or "localhost",
                 port=parsed_url.port or 6379,
                 db=int(parsed_url.path.lstrip("/")) if parsed_url.path and parsed_url.path != "/" else 0,
+                username=parsed_url.username,
                 password=parsed_url.password or password,
                 decode_responses=True,
             )


### PR DESCRIPTION
Fixes #254

## Summary

This PR fixes Redis ACL authentication by extracting the username from Redis URLs and passing it to the Redis client.

## Changes

- Added `username=parsed_url.username` to the Redis client initialization when parsing URLs
- Applied to both async and sync stores (sync generated via `make codegen`)

## Impact

This enables proper authentication for Redis servers using ACL (Redis 6+) where users authenticate with username/password pairs rather than just a password.

URLs like `redis://username:password@host:port/db` now work correctly.

## Testing

- Python linting: Passed
- Existing tests cover basic URL connection functionality

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redis connections now properly support usernames in connection URLs, enabling complete authentication configuration when initializing from URL strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->