### PR TITLE
fix: Add Docker CLI to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,12 @@
       "version": "lts"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "installDockerBuildx": false,
+      "installDockerComposeSwitch": false,
+      "moby": false
+    }
   },
   "runArgs": [
     "--network=host"


### PR DESCRIPTION
Add docker-in-docker feature to devcontainer to provide Docker CLI while using host Docker daemon via mounted socket. This allows `detect_docker()` in conftest.py to succeed, enabling Docker-based tests to run instead of being skipped.

Fixes #261

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to include Docker-in-Docker support with specific feature flags configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->