### PR TITLE
Simplify nightly dependency test workflow

### DIFF
--- a/.github/workflows/nightly-dependency-test.yml
+++ b/.github/workflows/nightly-dependency-test.yml
@@ -23,9 +23,6 @@ jobs:
             windows-2022,
             windows-latest,
           ]
-        project:
-          - "key-value/key-value-aio"
-          - "key-value/key-value-shared"
 
     runs-on: ${{ matrix.platform }}
 
@@ -48,19 +45,15 @@ jobs:
 
       - name: "Install latest dependencies (unpinned)"
         run: uv sync --group dev --python ${{ matrix.python-version }}
-        working-directory: ${{ matrix.project }}
 
       - name: "Show installed versions"
         run: uv pip list
-        working-directory: ${{ matrix.project }}
 
       - name: "Test with latest dependencies"
-        run: uv run pytest tests . -vv -n ${{ steps.pytest-workers.outputs.count }}
-        working-directory: ${{ matrix.project }}
+        run: uv run pytest tests -vv -n ${{ steps.pytest-workers.outputs.count }}
 
       - name: "Build"
         run: uv build .
-        working-directory: ${{ matrix.project }}
 
   create_issue_on_failure:
     needs: test_latest_dependencies


### PR DESCRIPTION
## Summary
Removed the matrix-based project selection from the nightly dependency test workflow, simplifying the CI configuration to run tests from the repository root instead of in specific project subdirectories.

## Key Changes
- Removed the `project` matrix variable that was iterating over `key-value/key-value-aio` and `key-value/key-value-shared`
- Eliminated all `working-directory` specifications from workflow steps, allowing them to run from the repository root
- Updated the pytest command to use `tests` instead of `tests .` for consistency

## Implementation Details
This change consolidates the nightly dependency testing to a single workflow run rather than multiple matrix jobs. The workflow now:
- Installs dependencies at the root level
- Runs pytest from the root directory
- Builds the package from the root directory

This simplification reduces CI complexity while maintaining test coverage, assuming the root-level configuration properly handles all necessary test scenarios.

https://claude.ai/code/session_01GKGS9QrhBZYXzZ2EiuhBoF