### PR TITLE
Add pytest integration marker for Docker-dependent tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: bump-version bump-version-dry lint typecheck sync precommit test build help
-.PHONY: install test-concise docs-serve docs-build docs-deploy
+.PHONY: install test-concise test-unit test-integration docs-serve docs-build docs-deploy
 
 # Default target - show help
 .DEFAULT_GOAL := help
@@ -13,6 +13,8 @@ help:
 	@echo "  make lint              - Run linters (Python + Markdown)"
 	@echo "  make typecheck         - Run type checking"
 	@echo "  make test              - Run all tests (verbose)"
+	@echo "  make test-unit         - Run unit tests only (no Docker)"
+	@echo "  make test-integration  - Run integration tests only (requires Docker)"
 	@echo "  make test-concise      - Run all tests (concise output for AI agents)"
 	@echo "  make build             - Build package"
 	@echo "  make precommit         - Run pre-commit checks (lint + typecheck)"
@@ -59,6 +61,16 @@ install: sync
 test:
 	@echo "Running tests..."
 	@uv run pytest tests -vv
+
+# Unit tests only (no Docker required)
+test-unit:
+	@echo "Running unit tests..."
+	@uv run pytest tests -vv -m "not integration"
+
+# Integration tests only (requires Docker)
+test-integration:
+	@echo "Running integration tests..."
+	@uv run pytest tests -vv -m "integration"
 
 # Concise test output for AI agents
 test-concise:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ addopts = [
 ]
 markers = [
     "skip_on_ci: Skip running the test when running on CI",
+    "integration: Tests that require Docker infrastructure",
 ]
 timeout = 10
 timeout_func_only = true

--- a/tests/stores/aerospike/test_aerospike.py
+++ b/tests/stores/aerospike/test_aerospike.py
@@ -16,7 +16,10 @@ from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 if TYPE_CHECKING:
     from key_value.aio.stores.aerospike import AerospikeStore
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Aerospike is not supported on Windows")
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="Aerospike is not supported on Windows"),
+]
 
 # Aerospike test configuration
 AEROSPIKE_NAMESPACE = "test"

--- a/tests/stores/dynamodb/test_dynamodb.py
+++ b/tests/stores/dynamodb/test_dynamodb.py
@@ -20,6 +20,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 # DynamoDB test configuration
 DYNAMODB_TEST_TABLE = "kv-store-test"
 

--- a/tests/stores/elasticsearch/test_elasticsearch.py
+++ b/tests/stores/elasticsearch/test_elasticsearch.py
@@ -22,6 +22,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 if TYPE_CHECKING:
     from elastic_transport._response import ObjectApiResponse
 

--- a/tests/stores/firestore/test_firestore.py
+++ b/tests/stores/firestore/test_firestore.py
@@ -16,6 +16,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 warnings.filterwarnings(
     "ignore",
     message=r"You are using a Python version .* google\.api_core",

--- a/tests/stores/memcached/test_memcached.py
+++ b/tests/stores/memcached/test_memcached.py
@@ -21,6 +21,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 # Memcached test configuration
 MEMCACHED_CONTAINER_PORT = 11211
 

--- a/tests/stores/mongodb/test_mongodb.py
+++ b/tests/stores/mongodb/test_mongodb.py
@@ -21,6 +21,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 # MongoDB test configuration
 MONGODB_TEST_DB = "kv-store-adapter-tests"
 

--- a/tests/stores/opensearch/test_opensearch.py
+++ b/tests/stores/opensearch/test_opensearch.py
@@ -23,6 +23,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 TEST_SIZE_LIMIT = 1 * 1024 * 1024  # 1MB
 
 OPENSEARCH_CONTAINER_PORT = 9200

--- a/tests/stores/postgresql/test_postgresql.py
+++ b/tests/stores/postgresql/test_postgresql.py
@@ -14,6 +14,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 try:
     import asyncpg
 except ImportError:

--- a/tests/stores/redis/test_redis.py
+++ b/tests/stores/redis/test_redis.py
@@ -14,6 +14,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 # Redis test configuration
 REDIS_DB = 15  # Use a separate database for tests
 

--- a/tests/stores/s3/test_s3.py
+++ b/tests/stores/s3/test_s3.py
@@ -12,6 +12,8 @@ from key_value.shared.wait import async_wait_for_true
 from tests.conftest import should_skip_docker_tests
 from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
 
+pytestmark = pytest.mark.integration
+
 # S3 test configuration (using LocalStack)
 S3_TEST_BUCKET = "kv-store-test"
 

--- a/tests/stores/valkey/test_valkey.py
+++ b/tests/stores/valkey/test_valkey.py
@@ -15,6 +15,8 @@ from tests.stores.base import (
     ContextManagerStoreTestMixin,
 )
 
+pytestmark = pytest.mark.integration
+
 # Valkey test configuration
 VALKEY_DB = 15
 VALKEY_CONTAINER_PORT = 6379

--- a/tests/stores/vault/test_vault.py
+++ b/tests/stores/vault/test_vault.py
@@ -9,6 +9,8 @@ from tests.stores.base import (
     BaseStoreTests,
 )
 
+pytestmark = pytest.mark.integration
+
 # Vault test configuration
 VAULT_TOKEN = "dev-root-token"
 VAULT_MOUNT_POINT = "secret"


### PR DESCRIPTION
- Add `integration` pytest marker to pyproject.toml
- Add `pytestmark = pytest.mark.integration` to all 12 Docker-dependent test files
- Add `make test-unit` and `make test-integration` convenience targets to Makefile

**Note:** The GitHub Actions workflow needs to be manually updated to use these markers. See the PR comments or issue #288 for the recommended workflow changes.

Closes #288

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/strawgate/py-key-value/tree/claude/issue-288-20260201-1425