### PR TITLE
fix: Remove keyring-linux extra to prevent dbus-python compile failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ opensearch = ["opensearch-py[async]>=2.0.0"]
 dynamodb = ["aioboto3>=13.3.0", "types-aiobotocore-dynamodb>=2.16.0"]
 s3 = ["aioboto3>=13.3.0", "types-aiobotocore-s3>=2.16.0"]
 keyring = ["keyring>=25.6.0"]
-keyring-linux = ["keyring>=25.6.0", "dbus-python>=1.4.0"]
 pydantic = ["pydantic>=2.11.9"]
 aerospike = ["aerospike>=16.0.0"]
 rocksdb = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'win32'",
@@ -756,12 +756,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dbus-python"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/24/63118050c7dd7be04b1ccd60eab53fef00abe844442e1b6dec92dae505d6/dbus-python-1.4.0.tar.gz", hash = "sha256:991666e498f60dbf3e49b8b7678f5559b8a65034fdf61aae62cdecdb7d89c770", size = 232490, upload-time = "2025-03-13T19:57:54.212Z" }
-
-[[package]]
 name = "dirty-equals"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -887,7 +881,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2070,10 +2064,6 @@ firestore = [
 keyring = [
     { name = "keyring" },
 ]
-keyring-linux = [
-    { name = "dbus-python" },
-    { name = "keyring" },
-]
 memcached = [
     { name = "aiomcache" },
 ]
@@ -2146,7 +2136,6 @@ requires-dist = [
     { name = "beartype", specifier = ">=0.20.0" },
     { name = "cachetools", marker = "extra == 'memory'", specifier = ">=5.0.0" },
     { name = "cryptography", marker = "extra == 'wrappers-encryption'", specifier = ">=45.0.0" },
-    { name = "dbus-python", marker = "extra == 'keyring-linux'", specifier = ">=1.4.0" },
     { name = "diskcache", marker = "extra == 'disk'", specifier = ">=5.0.0" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.1.1" },
     { name = "elasticsearch", marker = "extra == 'elasticsearch'", specifier = ">=8.0.0" },
@@ -2154,7 +2143,6 @@ requires-dist = [
     { name = "google-cloud-firestore", marker = "extra == 'firestore'", specifier = ">=2.13.0" },
     { name = "hvac", marker = "extra == 'vault'", specifier = ">=2.3.0" },
     { name = "keyring", marker = "extra == 'keyring'", specifier = ">=25.6.0" },
-    { name = "keyring", marker = "extra == 'keyring-linux'", specifier = ">=25.6.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.30.0" },
@@ -2173,7 +2161,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.15.0" },
     { name = "valkey-glide", marker = "extra == 'valkey'", specifier = ">=2.1.0" },
 ]
-provides-extras = ["memory", "disk", "filetree", "redis", "mongodb", "valkey", "vault", "memcached", "elasticsearch", "opensearch", "dynamodb", "s3", "keyring", "keyring-linux", "pydantic", "aerospike", "rocksdb", "duckdb", "postgresql", "firestore", "wrappers-encryption", "docs"]
+provides-extras = ["memory", "disk", "filetree", "redis", "mongodb", "valkey", "vault", "memcached", "elasticsearch", "opensearch", "dynamodb", "s3", "keyring", "pydantic", "aerospike", "rocksdb", "duckdb", "postgresql", "firestore", "wrappers-encryption", "docs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Removes the `keyring-linux` optional dependency extra that included `dbus-python>=1.4.0`, which requires system D-Bus development headers to compile.

**Why this is safe:**
- The base `keyring` extra already works on Linux via `jeepney` (pure Python)
- When D-Bus is unavailable, `keyring` gracefully falls back to runtime errors
- Users who need KWallet can install `dbus-python` manually

Fixes #294

---
Generated with [Claude Code](https://claude.ai/code)