### PR TITLE
Fix ai-github-actions workflow references and permissions

### DIFF
--- a/.github/workflows/trigger-docs-drift.yml
+++ b/.github/workflows/trigger-docs-drift.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-drift.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
     with:
       setup-commands: make setup
       messages-footer: |

--- a/.github/workflows/trigger-issue-triage.yml
+++ b/.github/workflows/trigger-issue-triage.yml
@@ -4,6 +4,7 @@ on:
     types: [opened]
 
 permissions:
+  actions: read
   contents: read
   discussions: write
   issues: write

--- a/.github/workflows/trigger-mention-in-issue.yml
+++ b/.github/workflows/trigger-mention-in-issue.yml
@@ -4,6 +4,7 @@ on:
     types: [created]
 
 permissions:
+  actions: read
   contents: write
   discussions: write
   issues: write

--- a/.github/workflows/trigger-mention-in-pr.yml
+++ b/.github/workflows/trigger-mention-in-pr.yml
@@ -6,6 +6,7 @@ on:
     types: [created]
 
 permissions:
+  actions: read
   contents: write
   discussions: write
   issues: write

--- a/.github/workflows/trigger-pr-actions-fixer.yml
+++ b/.github/workflows/trigger-pr-actions-fixer.yml
@@ -1,4 +1,4 @@
-name: PR Checks Fix
+name: PR Actions Fixer
 on:
   workflow_run:
     workflows: ["Run Tests"]
@@ -16,7 +16,7 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       toJSON(github.event.workflow_run.pull_requests) != '[]'
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-checks-fix.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-actions-fixer.lock.yml@main
     with:
       setup-commands: make setup
       messages-footer: |

--- a/.github/workflows/trigger-test-improvement.yml
+++ b/.github/workflows/trigger-test-improvement.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-test-improvement.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-test-improver.lock.yml@main
     with:
       setup-commands: make setup
       messages-footer: |


### PR DESCRIPTION
## Summary
- Renamed `docs-drift` → `docs-patrol` workflow reference
- Renamed `test-improvement` → `test-improver` workflow reference
- Replaced removed `pr-checks-fix` with `pr-actions-fixer` (file renamed accordingly)
- Added missing `actions: read` permission to `issue-triage`, `mention-in-issue`, and `mention-in-pr`

## Context
Detected by downstream upgrade check: elastic/ai-github-actions-cannon#12

## Test plan
- [ ] Verify docs-patrol runs on schedule
- [ ] Verify test-improver runs on schedule
- [ ] Verify pr-actions-fixer triggers on failed CI runs
- [ ] Verify issue-triage, mention-in-issue, and mention-in-pr still work correctly

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update GitHub Actions workflows to fix ai-github-actions references and add `permissions.actions: read` in [trigger-issue-triage.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-33fc0a3f2842916c18eb6eac833f7563cb733f489d5c257d131a09f034ceb099), [trigger-mention-in-issue.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-067275ffc8c79a7cf58e42f24da65a52429458cb1c1201bcabb916c0984f82e2), and [trigger-mention-in-pr.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-efa43c9b9a2d05dfb31694819b829c17d1687fb364886e4382eb91f36fe29a3c)
> Switch reusable workflow targets for docs patrol, PR actions fixer, and test improver, and set `actions: read` permissions on issue/pr mention and triage workflows; rename the PR checks fixer workflow display name.
>
> #### 📍Where to Start
> Start with the reusable workflow references in [trigger-docs-drift.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-16f9b4da94f0669e15384aea05e663f49e19ec8ebb1cb28a6c6ebc9a6fe3d7d8) and [trigger-pr-actions-fixer.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-68f6a54dcd31af8b9d8bc4455867c410d17b9218e77d79558cc3e43950a0c050), then review permission changes in [trigger-issue-triage.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-33fc0a3f2842916c18eb6eac833f7563cb733f489d5c257d131a09f034ceb099), [trigger-mention-in-issue.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-067275ffc8c79a7cf58e42f24da65a52429458cb1c1201bcabb916c0984f82e2), and [trigger-mention-in-pr.yml](https://github.com/strawgate/py-key-value/pull/333/files#diff-efa43c9b9a2d05dfb31694819b829c17d1687fb364886e4382eb91f36fe29a3c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4199eac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to include actions read scope for improved automation.
  * Renamed and updated internal workflow automation references to reflect current action naming conventions.
  * Updated workflow configuration for improved CI/CD pipeline management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->