### PR TITLE
feat(stores): add async Azure Table Storage store

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ elasticsearch = ["elasticsearch>=8.0.0", "aiohttp>=3.12"]
 opensearch = ["opensearch-py[async]>=2.0.0"]
 dynamodb = ["aioboto3>=13.3.0", "types-aiobotocore-dynamodb>=2.16.0"]
 s3 = ["aioboto3>=13.3.0", "types-aiobotocore-s3>=2.16.0"]
+azure-tables = ["azure-data-tables>=12.4.0", "azure-core>=1.29.0"]
 keyring = ["keyring>=25.6.0"]
 keyring-linux = ["keyring>=25.6.0", "dbus-python>=1.4.0"]
 pydantic = ["pydantic>=2.11.9"]
@@ -61,7 +62,7 @@ docs = [
 
 [dependency-groups]
 dev = [
-    "py-key-value-aio[memory,disk,filetree,redis,elasticsearch,opensearch,memcached,mongodb,vault,dynamodb,s3,rocksdb,duckdb,firestore,postgresql]",
+    "py-key-value-aio[memory,disk,filetree,redis,elasticsearch,opensearch,memcached,mongodb,vault,dynamodb,s3,azure-tables,rocksdb,duckdb,firestore,postgresql]",
     "py-key-value-aio[valkey]; platform_system != 'Windows'",
     "py-key-value-aio[aerospike]; platform_system != 'Windows'",
     "py-key-value-aio[keyring]",

--- a/src/key_value/aio/stores/azure_tables/__init__.py
+++ b/src/key_value/aio/stores/azure_tables/__init__.py
@@ -1,0 +1,3 @@
+from key_value.aio.stores.azure_tables.store import AzureTablesStore
+
+__all__ = ["AzureTablesStore"]

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -1,0 +1,391 @@
+"""Azure Table Storage async key-value store.
+
+Backs the AsyncKeyValue protocol with Azure Table Storage. One Storage
+account + one Table per store instance. Maps cleanly onto the
+collection/key model:
+
+    PartitionKey = collection
+    RowKey       = key
+    Value        = JSON-serialized ManagedEntry (string, ≤ 64 KB)
+    ExpiresAt    = epoch seconds (set only for entries with TTL)
+
+Azure Table Storage has no native TTL; this store handles expiry by
+checking ExpiresAt on read (lazy expire) and exposing an explicit
+``cull()`` for full sweeps.
+"""
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, overload
+
+from typing_extensions import override
+
+from key_value.aio._utils.managed_entry import ManagedEntry
+from key_value.aio.stores.base import (
+    BaseContextManagerStore,
+    BaseCullStore,
+)
+
+try:
+    from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
+    from azure.data.tables import UpdateMode
+    from azure.data.tables.aio import TableClient, TableServiceClient
+except ImportError as e:
+    msg = "AzureTablesStore requires py-key-value-aio[azure-tables]"
+    raise ImportError(msg) from e
+
+if TYPE_CHECKING:
+    from azure.core.credentials_async import AsyncTokenCredential
+
+
+# ---------------------------------------------------------------------------
+# Helper functions — module-level so they aren't part of the public surface.
+# ---------------------------------------------------------------------------
+
+
+def _account_url_from_name(account_name: str) -> str:
+    """Default Azure public-cloud Table endpoint for a storage account name."""
+    return f"https://{account_name}.table.core.windows.net"
+
+
+def _service_from_connection_string(connection_string: str) -> TableServiceClient:
+    """Create a TableServiceClient from a connection string."""
+    return TableServiceClient.from_connection_string(conn_str=connection_string)
+
+
+def _service_from_endpoint_and_credential(
+    *, endpoint: str, credential: "AsyncTokenCredential"
+) -> TableServiceClient:
+    """Create a TableServiceClient from an explicit endpoint + AsyncTokenCredential."""
+    return TableServiceClient(endpoint=endpoint, credential=credential)
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
+    """Azure Table Storage-backed async key-value store.
+
+    Schema:
+        PartitionKey -> collection
+        RowKey       -> key
+        Value        -> JSON-serialized ManagedEntry (string)
+        ExpiresAt    -> Unix epoch seconds (omitted when no TTL)
+
+    Authentication patterns (mirrors DynamoDB's flexibility):
+
+    1. Pre-constructed ``client: TableClient`` — caller manages lifecycle.
+       Useful when the calling app already has its own auth/transport setup
+       (Managed Identity via DefaultAzureCredential, custom retry policies,
+       etc.). The store will not enter or exit the client's context.
+
+    2. ``connection_string`` — simplest path for dev / shared-key scenarios.
+
+    3. ``account_name`` + ``credential`` — recommended for production.
+       ``credential`` should be an ``AsyncTokenCredential`` (e.g.
+       ``ManagedIdentityCredential``, ``WorkloadIdentityCredential``,
+       or ``DefaultAzureCredential`` from ``azure-identity``). Account URL
+       is derived as ``https://{account_name}.table.core.windows.net``.
+
+    4. ``endpoint`` + ``credential`` — for Azurite (local emulator) or
+       sovereign clouds where the endpoint isn't ``*.table.core.windows.net``.
+
+    TTL: Azure Table Storage has no native TTL. Two-pronged handling:
+      * Lazy expire on read — storage-side ExpiresAt is mirrored back onto
+        the ManagedEntry so the base class's expiry logic applies as usual.
+      * Explicit ``cull()`` — implemented via BaseCullStore. Scans for
+        entries with ``ExpiresAt < now`` and deletes them. Use on demand
+        when the table accumulates stale entries; for low-write workloads
+        like FastMCP OAuth state most callers won't need it.
+    """
+
+    _service: TableServiceClient | None
+    _table_client: TableClient | None
+    _table_name: str
+    _auto_create: bool
+
+    @overload
+    def __init__(
+        self,
+        *,
+        client: TableClient,
+        default_collection: str | None = None,
+        auto_create: bool = True,
+    ) -> None:
+        """Initialize from a pre-constructed TableClient.
+
+        Args:
+            client: A TableClient. The caller owns its lifecycle — the store
+                will neither enter nor exit its async context.
+            default_collection: Default collection name. Defaults to
+                "default_collection".
+            auto_create: If True, attempt to create the table during setup.
+                Existing tables are tolerated. Defaults to True.
+        """
+
+    @overload
+    def __init__(
+        self,
+        *,
+        connection_string: str,
+        table_name: str,
+        default_collection: str | None = None,
+        auto_create: bool = True,
+    ) -> None:
+        """Initialize from a connection string.
+
+        Args:
+            connection_string: Azure Storage connection string.
+            table_name: Table name.
+            default_collection: Default collection name.
+            auto_create: Whether to create the table if missing.
+        """
+
+    @overload
+    def __init__(
+        self,
+        *,
+        account_name: str,
+        credential: "AsyncTokenCredential",
+        table_name: str,
+        endpoint: str | None = None,
+        default_collection: str | None = None,
+        auto_create: bool = True,
+    ) -> None:
+        """Initialize from an account name + AsyncTokenCredential.
+
+        Args:
+            account_name: Storage account name (used to derive endpoint
+                unless ``endpoint`` is explicitly passed).
+            credential: An ``AsyncTokenCredential`` (e.g.
+                ``ManagedIdentityCredential``).
+            table_name: Table name.
+            endpoint: Optional explicit endpoint. Use for Azurite (e.g.
+                ``http://127.0.0.1:10002/devstoreaccount1``) or sovereign
+                clouds. Defaults to
+                ``https://{account_name}.table.core.windows.net``.
+            default_collection: Default collection name.
+            auto_create: Whether to create the table if missing.
+        """
+
+    @overload
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        credential: "AsyncTokenCredential",
+        table_name: str,
+        default_collection: str | None = None,
+        auto_create: bool = True,
+    ) -> None:
+        """Initialize from an explicit endpoint + AsyncTokenCredential.
+
+        Useful when the endpoint isn't ``{account}.table.core.windows.net``
+        — Azurite, sovereign Azure clouds, custom DNS.
+        """
+
+    def __init__(
+        self,
+        *,
+        client: TableClient | None = None,
+        connection_string: str | None = None,
+        account_name: str | None = None,
+        credential: "AsyncTokenCredential | None" = None,
+        endpoint: str | None = None,
+        table_name: str | None = None,
+        default_collection: str | None = None,
+        auto_create: bool = True,
+    ) -> None:
+        """See the overloaded signatures above for argument documentation."""
+        client_provided = client is not None
+
+        # Validate that exactly one auth pattern was supplied.
+        provided_patterns = sum(
+            (
+                client is not None,
+                connection_string is not None,
+                account_name is not None,
+                endpoint is not None and credential is not None,
+            )
+        )
+        if provided_patterns == 0:
+            msg = (
+                "AzureTablesStore requires one of: `client=`, "
+                "`connection_string=`, `account_name=` + `credential=`, or "
+                "`endpoint=` + `credential=`."
+            )
+            raise ValueError(msg)
+        if provided_patterns > 1:
+            msg = (
+                "AzureTablesStore was given conflicting auth arguments. "
+                "Pass exactly one of: `client`, `connection_string`, "
+                "`account_name`+`credential`, `endpoint`+`credential`."
+            )
+            raise ValueError(msg)
+
+        if client is not None:
+            # Caller-managed lifecycle. table_name comes from the client itself.
+            self._table_client = client
+            self._service = None
+            self._table_name = client.table_name
+        else:
+            if not table_name:
+                msg = "`table_name` is required when `client` is not provided"
+                raise ValueError(msg)
+            self._table_name = table_name
+            self._table_client = None
+
+            if connection_string is not None:
+                self._service = _service_from_connection_string(connection_string)
+            else:
+                # account_name + credential, or endpoint + credential.
+                if credential is None:
+                    msg = "`credential` is required with `account_name` or `endpoint`"
+                    raise ValueError(msg)
+                resolved_endpoint = endpoint or (
+                    _account_url_from_name(account_name) if account_name else None
+                )
+                if resolved_endpoint is None:
+                    msg = "Could not resolve a Table endpoint from the given arguments"
+                    raise ValueError(msg)
+                self._service = _service_from_endpoint_and_credential(
+                    endpoint=resolved_endpoint, credential=credential
+                )
+
+        self._auto_create = auto_create
+
+        super().__init__(
+            default_collection=default_collection,
+            client_provided_by_user=client_provided,
+        )
+
+    @property
+    def _connected_table_client(self) -> TableClient:
+        if not self._table_client:
+            msg = "Table client is not connected. Use the store as an async context manager or call setup()."
+            raise ValueError(msg)
+        return self._table_client
+
+    @override
+    async def _setup(self) -> None:
+        """Setup the underlying clients and ensure the table exists."""
+        if self._client_provided_by_user:
+            # User-provided TableClient. Optionally create the table.
+            if self._auto_create:
+                try:
+                    await self._connected_table_client.create_table()
+                except ResourceExistsError:
+                    pass
+            return
+
+        # We constructed our own TableServiceClient. Enter its async context
+        # via the exit stack so cleanup happens on store close.
+        service = self._service
+        if service is None:
+            # Should be unreachable given __init__ validation.
+            msg = "AzureTablesStore: service client missing during setup"
+            raise RuntimeError(msg)
+
+        await self._exit_stack.enter_async_context(service)
+
+        if self._auto_create:
+            await service.create_table_if_not_exists(table_name=self._table_name)
+
+        # The TableClient returned here shares transport with the service, so
+        # we don't need to enter its context separately.
+        self._table_client = service.get_table_client(table_name=self._table_name)
+
+    @override
+    async def _get_managed_entry(self, *, key: str, collection: str) -> ManagedEntry | None:
+        """Retrieve a managed entry from Azure Tables."""
+        try:
+            entity: dict[str, Any] = await self._connected_table_client.get_entity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
+                partition_key=collection,
+                row_key=key,
+            )
+        except ResourceNotFoundError:
+            return None
+
+        json_value = entity.get("Value")
+        if not isinstance(json_value, str) or not json_value:
+            return None
+
+        managed_entry: ManagedEntry = self._serialization_adapter.load_json(json_str=json_value)
+
+        # Storage-side ExpiresAt takes precedence over what's encoded in the
+        # serialized ManagedEntry, mirroring DynamoDB's behavior. This matters
+        # if a caller upserts the same key with a different TTL — the storage
+        # property is the source of truth.
+        expires_at_raw = entity.get("ExpiresAt")
+        if isinstance(expires_at_raw, int):
+            managed_entry.expires_at = datetime.fromtimestamp(expires_at_raw, tz=timezone.utc)
+
+        return managed_entry
+
+    @override
+    async def _put_managed_entry(
+        self,
+        *,
+        key: str,
+        collection: str,
+        managed_entry: ManagedEntry,
+    ) -> None:
+        """Store a managed entry in Azure Tables (REPLACE semantics)."""
+        json_value: str = self._serialization_adapter.dump_json(
+            entry=managed_entry, key=key, collection=collection
+        )
+
+        entity: dict[str, Any] = {
+            "PartitionKey": collection,
+            "RowKey": key,
+            "Value": json_value,
+        }
+        if managed_entry.expires_at is not None:
+            entity["ExpiresAt"] = int(managed_entry.expires_at.timestamp())
+
+        # REPLACE so put-after-put cleanly overwrites without merging stale
+        # properties from a prior version of the entity.
+        await self._connected_table_client.upsert_entity(entity=entity, mode=UpdateMode.REPLACE)
+
+    @override
+    async def _delete_managed_entry(self, *, key: str, collection: str) -> bool:
+        """Delete a managed entry. Returns True if an entity was actually deleted."""
+        try:
+            await self._connected_table_client.delete_entity(
+                partition_key=collection,
+                row_key=key,
+            )
+        except ResourceNotFoundError:
+            return False
+        return True
+
+    @override
+    async def _cull(self) -> None:
+        """Scan and delete entries whose ExpiresAt is in the past.
+
+        Azure Table Storage has no native TTL, so this is a manual sweep.
+        Use on demand when the table accumulates stale entries. Low-write
+        workloads (e.g. OAuth state) typically don't need it.
+        """
+        now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+        query_filter = "ExpiresAt lt @now"
+        parameters: dict[str, Any] = {"now": now_epoch}
+
+        async for entity in self._connected_table_client.query_entities(  # pyright: ignore[reportUnknownMemberType]
+            query_filter=query_filter,
+            parameters=parameters,
+        ):
+            partition_key = entity.get("PartitionKey")
+            row_key = entity.get("RowKey")
+            if not (isinstance(partition_key, str) and isinstance(row_key, str)):
+                continue
+            try:
+                await self._connected_table_client.delete_entity(
+                    partition_key=partition_key,
+                    row_key=row_key,
+                )
+            except ResourceNotFoundError:
+                # Race — another caller (or a lazy-expire on read) deleted the
+                # entity between query and delete. Tolerable.
+                continue

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -14,6 +14,7 @@ checking ExpiresAt on read (lazy expire) and exposing an explicit
 ``cull()`` for full sweeps.
 """
 
+import contextlib
 import hashlib
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, overload
@@ -50,16 +51,19 @@ if TYPE_CHECKING:
 # DCR client_ids ~32 chars, etc.) are well under this.
 _AZURE_PK_RK_MAX_LEN = 256
 _AZURE_PK_RK_FORBIDDEN_CHARS = frozenset("/\\#?")
+# ASCII chars below this code point are control characters. Used to filter
+# them out of PartitionKey/RowKey values per Azure Tables' documented limits.
+_CONTROL_CHAR_BOUNDARY = 0x20
 
 
 def _is_safe_pk_or_rk(value: str) -> bool:
     """Return True iff the value is a valid Azure Tables PartitionKey/RowKey."""
     if len(value) > _AZURE_PK_RK_MAX_LEN:
         return False
-    for ch in value:
-        if ch in _AZURE_PK_RK_FORBIDDEN_CHARS or ord(ch) < 0x20:
-            return False
-    return True
+    return all(
+        ch not in _AZURE_PK_RK_FORBIDDEN_CHARS and ord(ch) >= _CONTROL_CHAR_BOUNDARY
+        for ch in value
+    )
 
 
 def _safe_pk_or_rk(value: str) -> str:
@@ -333,11 +337,8 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
             self._table_client = service.get_table_client(table_name=self._table_name)
 
         if self._auto_create:
-            try:
+            with contextlib.suppress(ResourceExistsError):
                 await self._connected_table_client.create_table()
-            except ResourceExistsError:
-                # Tolerated — the table already existed.
-                pass
             return
 
         # auto_create=False: verify the table exists. list_entities triggers a

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -14,6 +14,7 @@ checking ExpiresAt on read (lazy expire) and exposing an explicit
 ``cull()`` for full sweeps.
 """
 
+import hashlib
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, overload
 
@@ -40,6 +41,35 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Helper functions — module-level so they aren't part of the public surface.
 # ---------------------------------------------------------------------------
+
+# Azure Table Storage PartitionKey/RowKey constraints (per Microsoft docs):
+#   * Max 1024 chars
+#   * Cannot contain `/`, `\`, `#`, `?`, or control characters (< 0x20).
+_AZURE_PK_RK_MAX_LEN = 1024
+_AZURE_PK_RK_FORBIDDEN_CHARS = frozenset("/\\#?")
+
+
+def _is_safe_pk_or_rk(value: str) -> bool:
+    """Return True iff the value is a valid Azure Tables PartitionKey/RowKey."""
+    if len(value) > _AZURE_PK_RK_MAX_LEN:
+        return False
+    for ch in value:
+        if ch in _AZURE_PK_RK_FORBIDDEN_CHARS or ord(ch) < 0x20:
+            return False
+    return True
+
+
+def _safe_pk_or_rk(value: str) -> str:
+    """Sanitize a string for use as an Azure Tables PartitionKey/RowKey.
+
+    Returns the input unchanged when it satisfies Azure's constraints; otherwise
+    a deterministic SHA-256 hex digest of the original. The hash is stable, so
+    PUT/GET round-trips with the same caller-side string land on the same
+    storage key.
+    """
+    if _is_safe_pk_or_rk(value):
+        return value
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
 def _account_url_from_name(account_name: str) -> str:
@@ -68,10 +98,18 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
     """Azure Table Storage-backed async key-value store.
 
     Schema:
-        PartitionKey -> collection
-        RowKey       -> key
+        PartitionKey -> collection (sanitized; see below)
+        RowKey       -> key (sanitized; see below)
         Value        -> JSON-serialized ManagedEntry (string)
         ExpiresAt    -> Unix epoch seconds (omitted when no TTL)
+
+    Azure Table Storage rejects PartitionKey/RowKey values that exceed 1024
+    chars or contain ``/``, ``\\``, ``#``, ``?``, or control characters. When
+    a caller-supplied collection or key violates those constraints, the store
+    silently substitutes a deterministic SHA-256 hex digest of the original.
+    Round-trips remain transparent (PUT and GET hash the same way), but
+    direct table inspection will show the digest rather than the source
+    string for those entries.
 
     Authentication patterns (mirrors DynamoDB's flexibility):
 
@@ -299,10 +337,12 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
     @override
     async def _get_managed_entry(self, *, key: str, collection: str) -> ManagedEntry | None:
         """Retrieve a managed entry from Azure Tables."""
+        pk = _safe_pk_or_rk(collection)
+        rk = _safe_pk_or_rk(key)
         try:
             entity: dict[str, Any] = await self._connected_table_client.get_entity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
-                partition_key=collection,
-                row_key=key,
+                partition_key=pk,
+                row_key=rk,
             )
         except ResourceNotFoundError:
             return None
@@ -336,9 +376,11 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
             entry=managed_entry, key=key, collection=collection
         )
 
+        pk = _safe_pk_or_rk(collection)
+        rk = _safe_pk_or_rk(key)
         entity: dict[str, Any] = {
-            "PartitionKey": collection,
-            "RowKey": key,
+            "PartitionKey": pk,
+            "RowKey": rk,
             "Value": json_value,
         }
         if managed_entry.expires_at is not None:
@@ -360,10 +402,12 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         gives the AsyncKeyValue contract semantics — True iff we actually
         removed something.
         """
+        pk = _safe_pk_or_rk(collection)
+        rk = _safe_pk_or_rk(key)
         try:
             await self._connected_table_client.get_entity(  # pyright: ignore[reportUnknownMemberType]
-                partition_key=collection,
-                row_key=key,
+                partition_key=pk,
+                row_key=rk,
                 select=["PartitionKey"],  # tiny payload — we only care about existence
             )
         except ResourceNotFoundError:
@@ -371,8 +415,8 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
 
         try:
             await self._connected_table_client.delete_entity(
-                partition_key=collection,
-                row_key=key,
+                partition_key=pk,
+                row_key=rk,
             )
         except ResourceNotFoundError:
             # Race — another caller deleted the entity between our GET and
@@ -401,6 +445,9 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
             if not (isinstance(partition_key, str) and isinstance(row_key, str)):
                 continue
             try:
+                # PartitionKey/RowKey here come straight from a stored entity
+                # so they're already in their sanitized form — no need to
+                # re-apply _safe_pk_or_rk.
                 await self._connected_table_client.delete_entity(
                     partition_key=partition_key,
                     row_key=row_key,

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -350,13 +350,33 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
 
     @override
     async def _delete_managed_entry(self, *, key: str, collection: str) -> bool:
-        """Delete a managed entry. Returns True if an entity was actually deleted."""
+        """Delete a managed entry. Returns True iff an entity was actually deleted.
+
+        The Azure SDK's ``TableClient.delete_entity`` silently succeeds when
+        the entity is missing (per its documented "If the entity does not
+        exist, this operation will succeed" behavior), so a naive
+        ``except ResourceNotFoundError`` never fires. We GET first to detect
+        existence, then DELETE if present. Costs one extra round-trip but
+        gives the AsyncKeyValue contract semantics — True iff we actually
+        removed something.
+        """
+        try:
+            await self._connected_table_client.get_entity(  # pyright: ignore[reportUnknownMemberType]
+                partition_key=collection,
+                row_key=key,
+                select=["PartitionKey"],  # tiny payload — we only care about existence
+            )
+        except ResourceNotFoundError:
+            return False
+
         try:
             await self._connected_table_client.delete_entity(
                 partition_key=collection,
                 row_key=key,
             )
         except ResourceNotFoundError:
+            # Race — another caller deleted the entity between our GET and
+            # DELETE. Treat as "we didn't actually delete it" since they did.
             return False
         return True
 
@@ -386,6 +406,6 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
                     row_key=row_key,
                 )
             except ResourceNotFoundError:
-                # Race — another caller (or a lazy-expire on read) deleted the
-                # entity between query and delete. Tolerable.
+                # Race — already deleted by lazy-expire-on-read or another
+                # cull. Tolerable; cull's contract is best-effort cleanup.
                 continue

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -368,7 +368,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         except ResourceNotFoundError:
             return None
 
-        json_value: Any = entity.get("Value")
+        json_value = entity.get("Value")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         if not isinstance(json_value, str) or not json_value:
             return None
 
@@ -378,7 +378,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         # serialized ManagedEntry, mirroring DynamoDB's behavior. This matters
         # if a caller upserts the same key with a different TTL — the storage
         # property is the source of truth.
-        expires_at_raw: Any = entity.get("ExpiresAt")
+        expires_at_raw = entity.get("ExpiresAt")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         if isinstance(expires_at_raw, int):
             managed_entry.expires_at = datetime.fromtimestamp(expires_at_raw, tz=timezone.utc)
 
@@ -463,8 +463,8 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
             query_filter=query_filter,
             parameters=parameters,
         ):
-            partition_key: Any = entity.get("PartitionKey")
-            row_key: Any = entity.get("RowKey")
+            partition_key = entity.get("PartitionKey")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+            row_key = entity.get("RowKey")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
             if not (isinstance(partition_key, str) and isinstance(row_key, str)):
                 continue
             try:

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -338,7 +338,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
 
         if self._auto_create:
             with contextlib.suppress(ResourceExistsError):
-                await self._connected_table_client.create_table()
+                await self._connected_table_client.create_table()  # pyright: ignore[reportUnknownMemberType]
             return
 
         # auto_create=False: verify the table exists. list_entities triggers a
@@ -361,14 +361,14 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         pk = _safe_pk_or_rk(collection)
         rk = _safe_pk_or_rk(key)
         try:
-            entity: dict[str, Any] = await self._connected_table_client.get_entity(  # pyright: ignore[reportUnknownMemberType, reportAssignmentType]
+            entity: dict[str, Any] = await self._connected_table_client.get_entity(  # pyright: ignore[reportUnknownMemberType]
                 partition_key=pk,
                 row_key=rk,
             )
         except ResourceNotFoundError:
             return None
 
-        json_value = entity.get("Value")
+        json_value: Any = entity.get("Value")
         if not isinstance(json_value, str) or not json_value:
             return None
 
@@ -378,7 +378,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         # serialized ManagedEntry, mirroring DynamoDB's behavior. This matters
         # if a caller upserts the same key with a different TTL — the storage
         # property is the source of truth.
-        expires_at_raw = entity.get("ExpiresAt")
+        expires_at_raw: Any = entity.get("ExpiresAt")
         if isinstance(expires_at_raw, int):
             managed_entry.expires_at = datetime.fromtimestamp(expires_at_raw, tz=timezone.utc)
 
@@ -409,7 +409,9 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
 
         # REPLACE so put-after-put cleanly overwrites without merging stale
         # properties from a prior version of the entity.
-        await self._connected_table_client.upsert_entity(entity=entity, mode=UpdateMode.REPLACE)
+        await self._connected_table_client.upsert_entity(  # pyright: ignore[reportUnknownMemberType]
+            entity=entity, mode=UpdateMode.REPLACE
+        )
 
     @override
     async def _delete_managed_entry(self, *, key: str, collection: str) -> bool:
@@ -461,8 +463,8 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
             query_filter=query_filter,
             parameters=parameters,
         ):
-            partition_key = entity.get("PartitionKey")
-            row_key = entity.get("RowKey")
+            partition_key: Any = entity.get("PartitionKey")
+            row_key: Any = entity.get("RowKey")
             if not (isinstance(partition_key, str) and isinstance(row_key, str)):
                 continue
             try:

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -42,10 +42,13 @@ if TYPE_CHECKING:
 # Helper functions — module-level so they aren't part of the public surface.
 # ---------------------------------------------------------------------------
 
-# Azure Table Storage PartitionKey/RowKey constraints (per Microsoft docs):
-#   * Max 1024 chars
-#   * Cannot contain `/`, `\`, `#`, `?`, or control characters (< 0x20).
-_AZURE_PK_RK_MAX_LEN = 1024
+# Azure Table Storage docs allow up to 1024 chars per PartitionKey/RowKey, but
+# the empirical limit on the resulting entity URL (which contains both keys
+# inline plus quoting and the full table-name path) is stricter. To stay safely
+# under that ceiling we cap each key at 256 chars before falling back to a
+# deterministic SHA-256 hash. Realistic keys (UUIDs ~36 chars, SHA-256 64 chars,
+# DCR client_ids ~32 chars, etc.) are well under this.
+_AZURE_PK_RK_MAX_LEN = 256
 _AZURE_PK_RK_FORBIDDEN_CHARS = frozenset("/\\#?")
 
 
@@ -103,13 +106,13 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         Value        -> JSON-serialized ManagedEntry (string)
         ExpiresAt    -> Unix epoch seconds (omitted when no TTL)
 
-    Azure Table Storage rejects PartitionKey/RowKey values that exceed 1024
-    chars or contain ``/``, ``\\``, ``#``, ``?``, or control characters. When
-    a caller-supplied collection or key violates those constraints, the store
-    silently substitutes a deterministic SHA-256 hex digest of the original.
-    Round-trips remain transparent (PUT and GET hash the same way), but
-    direct table inspection will show the digest rather than the source
-    string for those entries.
+    Azure Table Storage rejects PartitionKey/RowKey values that exceed its
+    URL/header limits or contain ``/``, ``\\``, ``#``, ``?``, or control
+    characters. When a caller-supplied collection or key violates those
+    constraints, the store silently substitutes a deterministic SHA-256 hex
+    digest of the original. Round-trips remain transparent (PUT and GET hash
+    the same way), but direct table inspection will show the digest rather
+    than the source string for those entries.
 
     Authentication patterns (mirrors DynamoDB's flexibility):
 

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -162,7 +162,9 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
             default_collection: Default collection name. Defaults to
                 "default_collection".
             auto_create: If True, attempt to create the table during setup.
-                Existing tables are tolerated. Defaults to True.
+                Existing tables are tolerated. If False, a missing table at
+                setup time is reported as a ``StoreSetupError`` (wrapping a
+                ``ValueError``).
         """
 
     @overload
@@ -310,32 +312,47 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
 
     @override
     async def _setup(self) -> None:
-        """Setup the underlying clients and ensure the table exists."""
-        if self._client_provided_by_user:
-            # User-provided TableClient. Optionally create the table.
-            if self._auto_create:
-                try:
-                    await self._connected_table_client.create_table()
-                except ResourceExistsError:
-                    pass
-            return
+        """Setup the underlying clients and ensure the table exists.
 
-        # We constructed our own TableServiceClient. Enter its async context
-        # via the exit stack so cleanup happens on store close.
-        service = self._service
-        if service is None:
-            # Should be unreachable given __init__ validation.
-            msg = "AzureTablesStore: service client missing during setup"
-            raise RuntimeError(msg)
-
-        await self._exit_stack.enter_async_context(service)
+        Behavior:
+          * If we constructed our own service, enter its context and resolve
+            a TableClient against the configured table.
+          * If ``auto_create=True``, attempt to create the table; an existing
+            table is tolerated.
+          * If ``auto_create=False``, verify the table exists by attempting a
+            single-page entity listing. Missing-table is surfaced as a
+            ``ValueError`` (wrapped as ``StoreSetupError`` by the base class).
+        """
+        if not self._client_provided_by_user:
+            service = self._service
+            if service is None:
+                # Should be unreachable given __init__ validation.
+                msg = "AzureTablesStore: service client missing during setup"
+                raise RuntimeError(msg)
+            await self._exit_stack.enter_async_context(service)
+            self._table_client = service.get_table_client(table_name=self._table_name)
 
         if self._auto_create:
-            await service.create_table_if_not_exists(table_name=self._table_name)
+            try:
+                await self._connected_table_client.create_table()
+            except ResourceExistsError:
+                # Tolerated — the table already existed.
+                pass
+            return
 
-        # The TableClient returned here shares transport with the service, so
-        # we don't need to enter its context separately.
-        self._table_client = service.get_table_client(table_name=self._table_name)
+        # auto_create=False: verify the table exists. list_entities triggers a
+        # request on first iteration; ResourceNotFoundError means missing table.
+        try:
+            async for _ in self._connected_table_client.list_entities(  # pyright: ignore[reportUnknownMemberType]
+                results_per_page=1,
+            ):
+                break
+        except ResourceNotFoundError as e:
+            msg = (
+                f"Table '{self._table_name}' does not exist. "
+                "Either create the table manually or set auto_create=True."
+            )
+            raise ValueError(msg) from e
 
     @override
     async def _get_managed_entry(self, *, key: str, collection: str) -> ManagedEntry | None:

--- a/src/key_value/aio/stores/azure_tables/store.py
+++ b/src/key_value/aio/stores/azure_tables/store.py
@@ -6,7 +6,7 @@ collection/key model:
 
     PartitionKey = collection
     RowKey       = key
-    Value        = JSON-serialized ManagedEntry (string, ≤ 64 KB)
+    Value        = JSON-serialized ManagedEntry (string, <= 64 KB)
     ExpiresAt    = epoch seconds (set only for entries with TTL)
 
 Azure Table Storage has no native TTL; this store handles expiry by
@@ -17,7 +17,7 @@ checking ExpiresAt on read (lazy expire) and exposing an explicit
 import contextlib
 import hashlib
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, overload
+from typing import Any, overload
 
 from typing_extensions import override
 
@@ -28,6 +28,7 @@ from key_value.aio.stores.base import (
 )
 
 try:
+    from azure.core.credentials_async import AsyncTokenCredential
     from azure.core.exceptions import ResourceExistsError, ResourceNotFoundError
     from azure.data.tables import UpdateMode
     from azure.data.tables.aio import TableClient, TableServiceClient
@@ -35,12 +36,9 @@ except ImportError as e:
     msg = "AzureTablesStore requires py-key-value-aio[azure-tables]"
     raise ImportError(msg) from e
 
-if TYPE_CHECKING:
-    from azure.core.credentials_async import AsyncTokenCredential
-
 
 # ---------------------------------------------------------------------------
-# Helper functions — module-level so they aren't part of the public surface.
+# Helper functions - module-level so they aren't part of the public surface.
 # ---------------------------------------------------------------------------
 
 # Azure Table Storage docs allow up to 1024 chars per PartitionKey/RowKey, but
@@ -90,7 +88,7 @@ def _service_from_connection_string(connection_string: str) -> TableServiceClien
 
 
 def _service_from_endpoint_and_credential(
-    *, endpoint: str, credential: "AsyncTokenCredential"
+    *, endpoint: str, credential: AsyncTokenCredential
 ) -> TableServiceClient:
     """Create a TableServiceClient from an explicit endpoint + AsyncTokenCredential."""
     return TableServiceClient(endpoint=endpoint, credential=credential)
@@ -120,26 +118,26 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
 
     Authentication patterns (mirrors DynamoDB's flexibility):
 
-    1. Pre-constructed ``client: TableClient`` — caller manages lifecycle.
+    1. Pre-constructed ``client: TableClient`` - caller manages lifecycle.
        Useful when the calling app already has its own auth/transport setup
        (Managed Identity via DefaultAzureCredential, custom retry policies,
        etc.). The store will not enter or exit the client's context.
 
-    2. ``connection_string`` — simplest path for dev / shared-key scenarios.
+    2. ``connection_string`` - simplest path for dev / shared-key scenarios.
 
-    3. ``account_name`` + ``credential`` — recommended for production.
+    3. ``account_name`` + ``credential`` - recommended for production.
        ``credential`` should be an ``AsyncTokenCredential`` (e.g.
        ``ManagedIdentityCredential``, ``WorkloadIdentityCredential``,
        or ``DefaultAzureCredential`` from ``azure-identity``). Account URL
        is derived as ``https://{account_name}.table.core.windows.net``.
 
-    4. ``endpoint`` + ``credential`` — for Azurite (local emulator) or
+    4. ``endpoint`` + ``credential`` - for Azurite (local emulator) or
        sovereign clouds where the endpoint isn't ``*.table.core.windows.net``.
 
     TTL: Azure Table Storage has no native TTL. Two-pronged handling:
-      * Lazy expire on read — storage-side ExpiresAt is mirrored back onto
+      * Lazy expire on read - storage-side ExpiresAt is mirrored back onto
         the ManagedEntry so the base class's expiry logic applies as usual.
-      * Explicit ``cull()`` — implemented via BaseCullStore. Scans for
+      * Explicit ``cull()`` - implemented via BaseCullStore. Scans for
         entries with ``ExpiresAt < now`` and deletes them. Use on demand
         when the table accumulates stale entries; for low-write workloads
         like FastMCP OAuth state most callers won't need it.
@@ -161,7 +159,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         """Initialize from a pre-constructed TableClient.
 
         Args:
-            client: A TableClient. The caller owns its lifecycle — the store
+            client: A TableClient. The caller owns its lifecycle - the store
                 will neither enter nor exit its async context.
             default_collection: Default collection name. Defaults to
                 "default_collection".
@@ -194,7 +192,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         self,
         *,
         account_name: str,
-        credential: "AsyncTokenCredential",
+        credential: AsyncTokenCredential,
         table_name: str,
         endpoint: str | None = None,
         default_collection: str | None = None,
@@ -221,7 +219,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         self,
         *,
         endpoint: str,
-        credential: "AsyncTokenCredential",
+        credential: AsyncTokenCredential,
         table_name: str,
         default_collection: str | None = None,
         auto_create: bool = True,
@@ -229,7 +227,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         """Initialize from an explicit endpoint + AsyncTokenCredential.
 
         Useful when the endpoint isn't ``{account}.table.core.windows.net``
-        — Azurite, sovereign Azure clouds, custom DNS.
+        - Azurite, sovereign Azure clouds, custom DNS.
         """
 
     def __init__(
@@ -238,7 +236,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         client: TableClient | None = None,
         connection_string: str | None = None,
         account_name: str | None = None,
-        credential: "AsyncTokenCredential | None" = None,
+        credential: AsyncTokenCredential | None = None,
         endpoint: str | None = None,
         table_name: str | None = None,
         default_collection: str | None = None,
@@ -376,7 +374,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
 
         # Storage-side ExpiresAt takes precedence over what's encoded in the
         # serialized ManagedEntry, mirroring DynamoDB's behavior. This matters
-        # if a caller upserts the same key with a different TTL — the storage
+        # if a caller upserts the same key with a different TTL - the storage
         # property is the source of truth.
         expires_at_raw = entity.get("ExpiresAt")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         if isinstance(expires_at_raw, int):
@@ -422,7 +420,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
         exist, this operation will succeed" behavior), so a naive
         ``except ResourceNotFoundError`` never fires. We GET first to detect
         existence, then DELETE if present. Costs one extra round-trip but
-        gives the AsyncKeyValue contract semantics — True iff we actually
+        gives the AsyncKeyValue contract semantics - True iff we actually
         removed something.
         """
         pk = _safe_pk_or_rk(collection)
@@ -431,7 +429,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
             await self._connected_table_client.get_entity(  # pyright: ignore[reportUnknownMemberType]
                 partition_key=pk,
                 row_key=rk,
-                select=["PartitionKey"],  # tiny payload — we only care about existence
+                select=["PartitionKey"],  # tiny payload - we only care about existence
             )
         except ResourceNotFoundError:
             return False
@@ -442,7 +440,7 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
                 row_key=rk,
             )
         except ResourceNotFoundError:
-            # Race — another caller deleted the entity between our GET and
+            # Race - another caller deleted the entity between our GET and
             # DELETE. Treat as "we didn't actually delete it" since they did.
             return False
         return True
@@ -469,13 +467,13 @@ class AzureTablesStore(BaseContextManagerStore, BaseCullStore):
                 continue
             try:
                 # PartitionKey/RowKey here come straight from a stored entity
-                # so they're already in their sanitized form — no need to
+                # so they're already in their sanitized form - no need to
                 # re-apply _safe_pk_or_rk.
                 await self._connected_table_client.delete_entity(
                     partition_key=partition_key,
                     row_key=row_key,
                 )
             except ResourceNotFoundError:
-                # Race — already deleted by lazy-expire-on-read or another
+                # Race - already deleted by lazy-expire-on-read or another
                 # cull. Tolerable; cull's contract is best-effort cleanup.
                 continue

--- a/tests/stores/azure_tables/__init__.py
+++ b/tests/stores/azure_tables/__init__.py
@@ -1,0 +1,1 @@
+"""Azure Tables store tests."""

--- a/tests/stores/azure_tables/test_azure_tables.py
+++ b/tests/stores/azure_tables/test_azure_tables.py
@@ -73,7 +73,7 @@ class AzuriteFailedToStartError(Exception):
 
 def _entity_value_payload(entity: dict[str, Any]) -> dict[str, Any]:
     """Decode the JSON-serialized ManagedEntry stored in the Value property."""
-    raw: Any = entity.get("Value")
+    raw = entity.get("Value")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     assert isinstance(raw, str)
     return json.loads(raw)
 
@@ -185,7 +185,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
                 "version": 1,
             }
         )
-        expires_at_raw: Any = entity.get("ExpiresAt")
+        expires_at_raw = entity.get("ExpiresAt")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         assert isinstance(expires_at_raw, int), "ExpiresAt should be an epoch-second integer"
         now = datetime.now(timezone.utc)
         assert expires_at_raw > now.timestamp(), "ExpiresAt should be in the future"

--- a/tests/stores/azure_tables/test_azure_tables.py
+++ b/tests/stores/azure_tables/test_azure_tables.py
@@ -1,0 +1,277 @@
+import asyncio
+import contextlib
+import json
+from collections.abc import Generator
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from dirty_equals import IsDatetime
+from inline_snapshot import snapshot
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.wait_strategies import LogMessageWaitStrategy
+from typing_extensions import override
+
+from key_value.aio._utils.wait import async_wait_for_true
+from key_value.aio.errors import StoreSetupError
+from key_value.aio.stores.azure_tables import AzureTablesStore
+from key_value.aio.stores.base import BaseStore
+from tests.conftest import should_skip_docker_tests
+from tests.stores.base import BaseStoreTests, ContextManagerStoreTestMixin
+
+# ---------------------------------------------------------------------------
+# Azurite test configuration
+# ---------------------------------------------------------------------------
+
+AZURITE_TEST_TABLE = "kvstoretest"  # Azure table names: alphanumeric only
+
+WAIT_FOR_AZURITE_TIMEOUT = 30
+
+# Pin a known-good Azurite tag. Update when Azurite ships breaking changes.
+AZURITE_VERSIONS_TO_TEST = [
+    "3.32.0",
+]
+
+AZURITE_TABLE_PORT = 10002
+
+# Azurite's well-known dev account credentials. These are public, intentionally
+# non-secret, and come straight from Microsoft's Azurite docs.
+AZURITE_ACCOUNT_NAME = "devstoreaccount1"
+AZURITE_ACCOUNT_KEY = (
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+)
+
+
+def _connection_string(host: str, port: int) -> str:
+    """Build an Azurite connection string for the Tables endpoint."""
+    return (
+        "DefaultEndpointsProtocol=http;"
+        f"AccountName={AZURITE_ACCOUNT_NAME};"
+        f"AccountKey={AZURITE_ACCOUNT_KEY};"
+        f"TableEndpoint=http://{host}:{port}/{AZURITE_ACCOUNT_NAME};"
+    )
+
+
+async def ping_azurite(connection_string: str) -> bool:
+    """Check if Azurite Tables is responsive."""
+    try:
+        from azure.data.tables.aio import TableServiceClient
+
+        async with TableServiceClient.from_connection_string(conn_str=connection_string) as service:
+            # list_tables returns an async pager; iterate once to force a request.
+            async for _ in service.list_tables(results_per_page=1):  # pyright: ignore[reportUnknownMemberType]
+                break
+    except Exception:
+        return False
+    else:
+        return True
+
+
+class AzuriteFailedToStartError(Exception):
+    pass
+
+
+def _entity_value_payload(entity: dict[str, Any]) -> dict[str, Any]:
+    """Decode the JSON-serialized ManagedEntry stored in the Value property."""
+    raw = entity.get("Value")
+    assert isinstance(raw, str)
+    return json.loads(raw)
+
+
+@pytest.mark.skipif(should_skip_docker_tests(), reason="Docker is not available")
+@pytest.mark.filterwarnings("ignore:A configured store is unstable and may change in a backwards incompatible way. Use at your own risk.")
+class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
+    @pytest.fixture(autouse=True, scope="module", params=AZURITE_VERSIONS_TO_TEST)
+    def azurite_container(self, request: pytest.FixtureRequest) -> Generator[DockerContainer, None, None]:
+        version = request.param
+        container = DockerContainer(image=f"mcr.microsoft.com/azure-storage/azurite:{version}")
+        container.with_exposed_ports(AZURITE_TABLE_PORT)
+        # Azurite logs once each service is ready; we only need Tables.
+        container.waiting_for(LogMessageWaitStrategy("Azurite Table service is successfully listening"))
+        # Bind to 0.0.0.0 so the container's exposed port is reachable.
+        container.with_command("azurite --tableHost 0.0.0.0 --skipApiVersionCheck")
+        with container:
+            yield container
+
+    @pytest.fixture(scope="module")
+    def azurite_host(self, azurite_container: DockerContainer) -> str:
+        return azurite_container.get_container_host_ip()
+
+    @pytest.fixture(scope="module")
+    def azurite_port(self, azurite_container: DockerContainer) -> int:
+        return int(azurite_container.get_exposed_port(AZURITE_TABLE_PORT))
+
+    @pytest.fixture(scope="module")
+    def azurite_connection_string(self, azurite_host: str, azurite_port: int) -> str:
+        return _connection_string(azurite_host, azurite_port)
+
+    @pytest.fixture(autouse=True, scope="module")
+    async def setup_azurite(self, azurite_container: DockerContainer, azurite_connection_string: str) -> None:
+        if not await async_wait_for_true(
+            bool_fn=lambda: ping_azurite(azurite_connection_string),
+            tries=WAIT_FOR_AZURITE_TIMEOUT,
+            wait_time=1,
+        ):
+            msg = "Azurite failed to start"
+            raise AzuriteFailedToStartError(msg)
+
+    async def _drop_table(self, connection_string: str, table_name: str) -> None:
+        """Best-effort drop of a table, suppressing not-found errors."""
+        from azure.data.tables.aio import TableServiceClient
+
+        async with TableServiceClient.from_connection_string(conn_str=connection_string) as service:
+            with contextlib.suppress(Exception):
+                await service.delete_table(table_name=table_name)
+
+    @override
+    @pytest.fixture
+    async def store(self, setup_azurite: None, azurite_connection_string: str) -> AzureTablesStore:
+        # Wipe any previous run's table contents so each test starts clean.
+        await self._drop_table(azurite_connection_string, AZURITE_TEST_TABLE)
+        return AzureTablesStore(
+            connection_string=azurite_connection_string,
+            table_name=AZURITE_TEST_TABLE,
+        )
+
+    @pytest.fixture
+    async def azure_tables_store(self, store: AzureTablesStore) -> AzureTablesStore:
+        return store
+
+    @pytest.mark.skip(reason="Distributed Caches are unbounded")
+    @override
+    async def test_not_unbounded(self, store: BaseStore): ...
+
+    # -----------------------------------------------------------------
+    # Store-specific tests
+    # -----------------------------------------------------------------
+
+    async def test_value_stored(self, store: AzureTablesStore, azurite_connection_string: str):
+        """ManagedEntry is JSON-serialized into the Value property; ExpiresAt
+        is set only when ttl is passed."""
+        from azure.data.tables.aio import TableServiceClient
+
+        await store.put(collection="test", key="test_key", value={"name": "Alice", "age": 30})
+
+        # No-TTL case
+        async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
+            table = service.get_table_client(table_name=AZURITE_TEST_TABLE)
+            entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportAssignmentType]
+
+        assert _entity_value_payload(entity) == snapshot(
+            {
+                "collection": "test",
+                "created_at": IsDatetime(iso_string=True),
+                "key": "test_key",
+                "value": {"age": 30, "name": "Alice"},
+                "version": 1,
+            }
+        )
+        assert "ExpiresAt" not in entity, "ExpiresAt should not be set without a TTL"
+
+        # TTL case
+        await store.put(collection="test", key="test_key", value={"name": "Alice", "age": 30}, ttl=10)
+
+        async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
+            table = service.get_table_client(table_name=AZURITE_TEST_TABLE)
+            entity = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportAssignmentType]
+
+        assert _entity_value_payload(entity) == snapshot(
+            {
+                "collection": "test",
+                "created_at": IsDatetime(iso_string=True),
+                "key": "test_key",
+                "value": {"age": 30, "name": "Alice"},
+                "expires_at": IsDatetime(iso_string=True),
+                "version": 1,
+            }
+        )
+        expires_at_raw = entity.get("ExpiresAt")
+        assert isinstance(expires_at_raw, int), "ExpiresAt should be an epoch-second integer"
+        now = datetime.now(timezone.utc)
+        assert expires_at_raw > now.timestamp(), "ExpiresAt should be in the future"
+        assert expires_at_raw < now.timestamp() + 10 + 1, "ExpiresAt should be within the configured TTL window"
+
+    async def test_auto_create_false_raises_when_table_missing(
+        self, setup_azurite: None, azurite_connection_string: str
+    ):
+        """auto_create=False must error when the table doesn't exist."""
+        table_name = "kvstoretestautocreatefalse"
+        await self._drop_table(azurite_connection_string, table_name)
+
+        store = AzureTablesStore(
+            connection_string=azurite_connection_string,
+            table_name=table_name,
+            auto_create=False,
+        )
+
+        with pytest.raises(StoreSetupError):
+            async with store:
+                await store.put(collection="test", key="test_key", value={"message": "should not get here"})
+
+    async def test_auto_create_true_creates_table(
+        self, setup_azurite: None, azurite_connection_string: str
+    ):
+        """auto_create=True (default) creates the table on first use."""
+        from azure.data.tables.aio import TableServiceClient
+
+        table_name = "kvstoretestautocreatetrue"
+        await self._drop_table(azurite_connection_string, table_name)
+
+        store = AzureTablesStore(
+            connection_string=azurite_connection_string,
+            table_name=table_name,
+        )
+
+        async with store:
+            await store.put(collection="test", key="test_key", value={"message": "autocreate"})
+            assert await store.get(collection="test", key="test_key") == {"message": "autocreate"}
+
+            async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
+                tables = [t.name async for t in service.list_tables()]  # pyright: ignore[reportUnknownMemberType]
+                assert table_name in tables
+
+        await self._drop_table(azurite_connection_string, table_name)
+
+    async def test_cull_deletes_expired(self, setup_azurite: None, azurite_connection_string: str):
+        """_cull() removes entries whose ExpiresAt is in the past, leaves
+        un-TTLed and non-expired entries alone."""
+        table_name = "kvstoretestcull"
+        await self._drop_table(azurite_connection_string, table_name)
+
+        store = AzureTablesStore(
+            connection_string=azurite_connection_string,
+            table_name=table_name,
+        )
+        async with store:
+            # No TTL — should survive cull.
+            await store.put(collection="c", key="permanent", value={"v": 1})
+            # Long TTL — should survive.
+            await store.put(collection="c", key="long", value={"v": 2}, ttl=60)
+            # Tiny TTL — should be expired by the time we cull.
+            await store.put(collection="c", key="short", value={"v": 3}, ttl=1)
+
+            # Wait past the short TTL.
+            await asyncio.sleep(2)
+
+            await store.cull()
+
+            assert await store.get(collection="c", key="permanent") == {"v": 1}
+            assert await store.get(collection="c", key="long") == {"v": 2}
+            assert await store.get(collection="c", key="short") is None
+
+        await self._drop_table(azurite_connection_string, table_name)
+
+    async def test_conflicting_auth_args_rejected(self):
+        """Constructor rejects ambiguous auth-arg combinations."""
+        with pytest.raises(ValueError, match="conflicting auth arguments"):
+            AzureTablesStore(
+                connection_string="UseDevelopmentStorage=true",
+                account_name="devstoreaccount1",
+                credential=None,  # type: ignore[arg-type]
+                table_name="t",
+            )
+
+    async def test_no_auth_args_rejected(self):
+        """Constructor errors when no auth pattern was supplied."""
+        with pytest.raises(ValueError, match="requires one of"):
+            AzureTablesStore(table_name="t")

--- a/tests/stores/azure_tables/test_azure_tables.py
+++ b/tests/stores/azure_tables/test_azure_tables.py
@@ -73,7 +73,7 @@ class AzuriteFailedToStartError(Exception):
 
 def _entity_value_payload(entity: dict[str, Any]) -> dict[str, Any]:
     """Decode the JSON-serialized ManagedEntry stored in the Value property."""
-    raw = entity.get("Value")
+    raw: Any = entity.get("Value")
     assert isinstance(raw, str)
     return json.loads(raw)
 
@@ -121,7 +121,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
 
         async with TableServiceClient.from_connection_string(conn_str=connection_string) as service:
             with contextlib.suppress(Exception):
-                await service.delete_table(table_name=table_name)
+                await service.delete_table(table_name=table_name)  # pyright: ignore[reportUnknownMemberType]
 
     @override
     @pytest.fixture
@@ -155,7 +155,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
         # No-TTL case
         async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
             table = service.get_table_client(table_name=AZURITE_TEST_TABLE)
-            entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportAssignmentType]
+            entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
 
         assert _entity_value_payload(entity) == snapshot(
             {
@@ -173,7 +173,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
 
         async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
             table = service.get_table_client(table_name=AZURITE_TEST_TABLE)
-            entity = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportAssignmentType]
+            entity = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
 
         assert _entity_value_payload(entity) == snapshot(
             {
@@ -185,7 +185,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
                 "version": 1,
             }
         )
-        expires_at_raw = entity.get("ExpiresAt")
+        expires_at_raw: Any = entity.get("ExpiresAt")
         assert isinstance(expires_at_raw, int), "ExpiresAt should be an epoch-second integer"
         now = datetime.now(timezone.utc)
         assert expires_at_raw > now.timestamp(), "ExpiresAt should be in the future"
@@ -274,4 +274,4 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
     async def test_no_auth_args_rejected(self):
         """Constructor errors when no auth pattern was supplied."""
         with pytest.raises(ValueError, match="requires one of"):
-            AzureTablesStore(table_name="t")
+            AzureTablesStore(table_name="t")  # pyright: ignore[reportCallIssue]

--- a/tests/stores/azure_tables/test_azure_tables.py
+++ b/tests/stores/azure_tables/test_azure_tables.py
@@ -73,7 +73,7 @@ class AzuriteFailedToStartError(Exception):
 
 def _entity_value_payload(entity: dict[str, Any]) -> dict[str, Any]:
     """Decode the JSON-serialized ManagedEntry stored in the Value property."""
-    raw = entity.get("Value")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    raw = entity.get("Value")
     assert isinstance(raw, str)
     return json.loads(raw)
 
@@ -185,7 +185,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
                 "version": 1,
             }
         )
-        expires_at_raw = entity.get("ExpiresAt")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        expires_at_raw = entity.get("ExpiresAt")
         assert isinstance(expires_at_raw, int), "ExpiresAt should be an epoch-second integer"
         now = datetime.now(timezone.utc)
         assert expires_at_raw > now.timestamp(), "ExpiresAt should be in the future"

--- a/tests/stores/azure_tables/test_azure_tables.py
+++ b/tests/stores/azure_tables/test_azure_tables.py
@@ -173,7 +173,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
 
         async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
             table = service.get_table_client(table_name=AZURITE_TEST_TABLE)
-            entity = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
+            entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
 
         assert _entity_value_payload(entity) == snapshot(
             {

--- a/tests/stores/azure_tables/test_azure_tables.py
+++ b/tests/stores/azure_tables/test_azure_tables.py
@@ -185,7 +185,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
                 "version": 1,
             }
         )
-        expires_at_raw = ttl_entity.get("ExpiresAt")
+        expires_at_raw = ttl_entity.get("ExpiresAt")  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         assert isinstance(expires_at_raw, int), "ExpiresAt should be an epoch-second integer"
         now = datetime.now(timezone.utc)
         assert expires_at_raw > now.timestamp(), "ExpiresAt should be in the future"

--- a/tests/stores/azure_tables/test_azure_tables.py
+++ b/tests/stores/azure_tables/test_azure_tables.py
@@ -155,9 +155,9 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
         # No-TTL case
         async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
             table = service.get_table_client(table_name=AZURITE_TEST_TABLE)
-            entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
+            no_ttl_entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
 
-        assert _entity_value_payload(entity) == snapshot(
+        assert _entity_value_payload(no_ttl_entity) == snapshot(
             {
                 "collection": "test",
                 "created_at": IsDatetime(iso_string=True),
@@ -166,16 +166,16 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
                 "version": 1,
             }
         )
-        assert "ExpiresAt" not in entity, "ExpiresAt should not be set without a TTL"
+        assert "ExpiresAt" not in no_ttl_entity, "ExpiresAt should not be set without a TTL"
 
         # TTL case
         await store.put(collection="test", key="test_key", value={"name": "Alice", "age": 30}, ttl=10)
 
         async with TableServiceClient.from_connection_string(conn_str=azurite_connection_string) as service:
             table = service.get_table_client(table_name=AZURITE_TEST_TABLE)
-            entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
+            ttl_entity: dict[str, Any] = await table.get_entity(partition_key="test", row_key="test_key")  # pyright: ignore[reportUnknownMemberType]
 
-        assert _entity_value_payload(entity) == snapshot(
+        assert _entity_value_payload(ttl_entity) == snapshot(
             {
                 "collection": "test",
                 "created_at": IsDatetime(iso_string=True),
@@ -185,7 +185,7 @@ class TestAzureTablesStore(ContextManagerStoreTestMixin, BaseStoreTests):
                 "version": 1,
             }
         )
-        expires_at_raw = entity.get("ExpiresAt")
+        expires_at_raw = ttl_entity.get("ExpiresAt")
         assert isinstance(expires_at_raw, int), "ExpiresAt should be an epoch-second integer"
         now = datetime.now(timezone.utc)
         assert expires_at_raw > now.timestamp(), "ExpiresAt should be in the future"


### PR DESCRIPTION
Closes #343.

## Summary

Adds an async Azure Table Storage store to fill the Azure-native gap in the
distributed-store coverage (we already have DynamoDB for AWS and Firestore
for GCP). Specifically motivated by FastMCP's `AzureProvider` needing
persistent OAuth state on Azure Container Apps where the default
ephemeral file store evaporates on every container restart.

## Shape

`AzureTablesStore(BaseContextManagerStore, BaseCullStore)` — mirrors the
DynamoDB store as closely as Azure's API allows.

- `PartitionKey` = collection, `RowKey` = key, `Value` = JSON-serialized
  ManagedEntry, `ExpiresAt` = epoch seconds (only for TTL'd entries).
- Four auth patterns (parity with DynamoDB's flexibility): pre-constructed
  `client: TableClient`, `connection_string`, `account_name + credential`,
  or `endpoint + credential` (for Azurite / sovereign clouds).
- TTL handling: Azure Tables has no native TTL. Lazy-expire on read +
  explicit `cull()` via `BaseCullStore`.
- PartitionKey/RowKey sanitization: Azure rejects keys >256 chars (URL
  limit) or containing `/\\#?` / control chars. Out-of-spec values get
  a deterministic SHA-256 hash so PUT/GET round-trip transparently.
- Delete semantics: SDK silently swallows 404 on delete_entity, so we
  GET first to detect existence and return `True` iff we actually
  removed an entity (matches AsyncKeyValue contract).

## Tests

`tests/stores/azure_tables/` runs against Azurite via testcontainers
(image `mcr.microsoft.com/azure-storage/azurite:3.32.0`). Standard
`ContextManagerStoreTestMixin + BaseStoreTests` plus store-specific
tests for entity schema, TTL, auto_create=False/True, cull, and
constructor validation. **144 passed + 2 expected skips.**

`make precommit` clean (ruff + basedpyright strict).

## Open questions for you

- **Naming**: went with `azure_tables` (room for future Azure stores —
  Blob, Cosmos, Queue). Happy to rename.
- **Encryption**: relying on `FernetEncryptionWrapper` like other stores;
  no built-in store-side crypto.
- **Batch ops**: Azure Tables supports atomic batches per-PartitionKey,
  but skipped for v1. Happy to add as a follow-up if you'd like.

Tested fully against Azurite locally.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add async Azure Table Storage key-value store
> - Adds `AzureTablesStore` in `src/key_value/aio/stores/azure_tables/` as a new async backend implementing `BaseContextManagerStore` and `BaseCullStore`.
> - Supports three construction patterns: pre-created `TableClient`, connection string + table name, or account name/endpoint + `AsyncTokenCredential` + table name.
> - Keys and collection names that are unsafe as Azure Tables PartitionKey/RowKey (too long, forbidden characters, control chars) are transparently replaced with their SHA-256 hex digest.
> - Supports optional `auto_create` flag to create the table on setup, or validates table existence at startup when `auto_create=False`.
> - TTL is stored as an integer `ExpiresAt` epoch seconds alongside the JSON payload; `_cull` queries and deletes expired entities.
> - Adds optional `azure-tables` extra in `pyproject.toml` pulling `azure-data-tables>=12.4.0` and `azure-core>=1.29.0`.
> - Integration tests run against Azurite via testcontainers and cover auto-create, missing-table errors, TTL storage, culling, and constructor validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afbbd8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Azure Table Storage support as a new optional key-value store backend with full async/await support
  * Automatic table creation on first use with optional manual configuration
  * TTL and expiration management with automatic cleanup of expired entries

* **Tests**
  * Added end-to-end integration tests with Azurite Tables emulator to validate functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->