### PR TITLE
Bump uv_build build constraint to >=0.11.4 to fix hermetic builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.8.2,<0.9.0"]
+requires = ["uv_build>=0.11.4"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
Fixes #341

## Summary

- Bumps the `[build-system]` `requires` constraint from `uv_build>=0.8.2,<0.9.0` to `uv_build>=0.11.4`
- All uv-build releases < 0.11.4 ship a **stale `Cargo.lock`** in their sdist, causing `cargo --locked` to fail when the build backend is compiled from source in hermetic environments (Nix, air-gapped CI, vendored builds)
- The upstream fix landed in uv-build 0.11.4 via [astral-sh/uv#18831](https://github.com/astral-sh/uv/pull/18831)

## Steps to reproduce

### Prerequisites

```bash
cargo --version   # needs Rust toolchain
pip --version
```

### 1. Download the old and new uv_build sdists

```bash
pip download "uv_build>=0.8.2,<0.9.0" --no-binary uv_build -d /tmp/uv_build_old --no-deps
pip download "uv_build>=0.11.4"        --no-binary uv_build -d /tmp/uv_build_new --no-deps
```

### 2. Reproduce the failure with uv_build 0.8.x (old constraint)

```bash
cd /tmp && tar -xzf uv_build_old/uv_build-0.8.24.tar.gz
cd uv_build-0.8.24 && cargo build --locked
```

Expected output (the hermetic build failure):

```
error: cannot update the lock file /tmp/uv_build-0.8.24/Cargo.lock because --locked was passed to prevent this
help: to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

### 3. Verify the fix with uv_build 0.11.4+ (new constraint)

```bash
cd /tmp && tar -xzf uv_build_new/uv_build-0.11.8.tar.gz
cd uv_build-0.11.8 && cargo build --locked
```

Expected output:

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 38s
```

### Why this affects py-key-value-aio

In a hermetic build environment, the build backend listed under `[build-system]` must itself be buildable from source with `cargo --locked`. With the old `<0.9.0` cap, the resolver picks uv_build 0.8.x whose sdist contains a stale `Cargo.lock`, breaking any tool (Nix, Bazel, air-gapped CI) that enforces `--locked`. Removing the upper cap and raising the floor to `>=0.11.4` ensures the fixed sdist is always used.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `uv_build` build constraint to `>=0.11.4` to fix hermetic builds
> Updates [pyproject.toml](https://github.com/strawgate/py-key-value/pull/347/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) to raise the minimum `uv_build` version from `0.8.2` to `0.11.4` and removes the previous `<0.9.0` upper bound. Risk: environments with `uv_build` below `0.11.4` will no longer build the project.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd058be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->