### PR TITLE
Fix FileTreeStore delete race

### DIFF
--- a/src/key_value/aio/stores/filetree/store.py
+++ b/src/key_value/aio/stores/filetree/store.py
@@ -290,10 +290,10 @@ class DiskCollectionInfo:
         # Security validation
         await self._validate_path_security(path=key_path)
 
-        if not await key_path.exists():
+        try:
+            await key_path.unlink()
+        except FileNotFoundError:
             return False
-
-        await key_path.unlink()
 
         return True
 

--- a/tests/stores/filetree/test_filetree.py
+++ b/tests/stores/filetree/test_filetree.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 import pytest
+from anyio import Path as AsyncPath
 from typing_extensions import override
 
 from key_value.aio._utils.sanitization import PassthroughStrategy
@@ -37,6 +38,27 @@ class TestFileTreeStore(BaseStoreTests):
     async def test_not_unbounded(self, store: BaseStore):
         """FileTreeStore is unbounded, so skip this test."""
         pytest.skip("FileTreeStore is unbounded and does not evict old entries")
+
+    async def test_delete_returns_false_when_file_disappears_before_unlink(
+        self,
+        store: FileTreeStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """delete should remain idempotent when another actor removes the file first."""
+        await store.put(collection="test", key="race_key", value={"data": "value"})
+
+        original_unlink = AsyncPath.unlink
+
+        async def unlink_after_external_removal(path: AsyncPath) -> None:
+            if Path(path).name == "race_key.json":
+                Path(path).unlink()
+                raise FileNotFoundError(Path(path))
+            await original_unlink(path)
+
+        monkeypatch.setattr(AsyncPath, "unlink", unlink_after_external_removal)
+
+        assert await store.delete(collection="test", key="race_key") is False
+        assert await store.get(collection="test", key="race_key") is None
 
 
 class TestFileTreeStorePathTraversal:


### PR DESCRIPTION
## Summary

- remove the exists/unlink TOCTOU window in FileTreeStore delete_entry
- return False when unlink reports the file is already gone
- add a deterministic regression test for a same-key delete race

Closes #354

## Validation

- python -m uv run pytest tests/stores/filetree/test_filetree.py::TestFileTreeStore::test_delete_returns_false_when_file_disappears_before_unlink -q
- python -m uv run pytest tests/stores/filetree/test_filetree.py -q
- python -m uv run ruff check src/key_value/aio/stores/filetree/store.py tests/stores/filetree/test_filetree.py
- python -m uv run ruff format --check src/key_value/aio/stores/filetree/store.py tests/stores/filetree/test_filetree.py
- make typecheck

## Notes

`make test-concise` was also attempted and reached the MongoDB tests, but the run stopped because the mongo:8.0 testcontainer exited during startup with the upstream Linux kernel 6.19+ incompatibility message. The failure was outside the touched FileTreeStore path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file deletion resilience: deletion operations now gracefully handle cases where files have been removed externally, ensuring consistent behavior.

* **Tests**
  * Added test coverage verifying idempotent deletion behavior when files are unexpectedly missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strawgate/py-key-value/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->