### PR TITLE
Document Redis TLS connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ FastMCP users can plug in any store implementation:
    framework = YourFramework(
        cache=RedisStore(url="redis://localhost:6379/0")
    )
+
+   # Production with Redis TLS
+   framework = YourFramework(
+       cache=RedisStore(
+           url="rediss://redis.example.com:6380/0",
+           ssl_ca_certs="/etc/ssl/certs/redis-ca.pem",
+       )
+   )
    ```
 
 By depending on `py-key-value-aio` instead of a specific storage backend,

--- a/docs/api/stores.md
+++ b/docs/api/stores.md
@@ -43,6 +43,11 @@ Redis-backed key-value store.
       members:
         - __init__
 
+Redis TLS is configured on `RedisStore.__init__`. Use a `rediss://` URL to
+enable TLS from the URL scheme, or pass `ssl=True` with `host` and `port`.
+Certificate options are exposed as `ssl_ca_certs`, `ssl_certfile`,
+`ssl_keyfile`, `ssl_check_hostname`, and `ssl_cert_reqs`.
+
 ## DynamoDB Store
 
 AWS DynamoDB-backed key-value store.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,6 +151,16 @@ from key_value.aio.stores.redis import RedisStore
 store = RedisStore(url="redis://localhost:6379/0")
 ```
 
+For Redis deployments that require TLS, use a `rediss://` URL or pass
+`ssl=True` with the certificate options your deployment requires:
+
+```python
+store = RedisStore(
+    url="rediss://redis.example.com:6380/0",
+    ssl_ca_certs="/etc/ssl/certs/redis-ca.pem",
+)
+```
+
 ### DynamoDB
 
 ```python
@@ -270,6 +280,14 @@ framework = YourFramework(cache=MemoryStore())
 # Production
 framework = YourFramework(
     cache=RedisStore(url="redis://localhost:6379/0")
+)
+
+# Production with Redis TLS
+framework = YourFramework(
+    cache=RedisStore(
+        url="rediss://redis.example.com:6380/0",
+        ssl_ca_certs="/etc/ssl/certs/redis-ca.pem",
+    )
 )
 ```
 

--- a/docs/stores.md
+++ b/docs/stores.md
@@ -562,7 +562,18 @@ High-performance in-memory store using Redis.
 from key_value.aio.stores.redis import RedisStore
 
 store = RedisStore(url="redis://localhost:6379/0")
+
+tls_store = RedisStore(
+    url="rediss://redis.example.com:6380/0",
+    ssl_ca_certs="/etc/ssl/certs/redis-ca.pem",
+)
 ```
+
+Redis TLS can be enabled with a `rediss://` URL or with `ssl=True` when using
+`host` and `port`. Pass `ssl_ca_certs` to verify the server certificate, and
+`ssl_certfile` plus `ssl_keyfile` for mutual TLS deployments. For development
+or test environments with self-signed certificates, `ssl_cert_reqs="none"` and
+`ssl_check_hostname=False` are available, but should not be used for production.
 
 **Installation:**
 
@@ -583,6 +594,7 @@ pip install py-key-value-aio[redis]
 - Production-ready
 - Rich feature set
 - Horizontal scaling support
+- SSL/TLS and mutual TLS connection options
 - **Stable storage format**
 
 ---


### PR DESCRIPTION
## Summary
- document RedisStore TLS usage in README and getting-started examples
- add Redis TLS/mTLS guidance to the store guide
- call out RedisStore SSL parameters in the API stores page

Fixes #342

## Verification
- make precommit
- make docs-build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Redis store documentation with comprehensive TLS/SSL configuration guidance, including examples of secure connection setup using encrypted Redis URLs and certificate options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strawgate/py-key-value/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->