### PR TITLE
Add AsyncKeyValue protocol to protocols.md

### DIFF
--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -11,3 +11,9 @@ composability.
       show_source: true
       members: true
       show_root_heading: true
+      class AsyncKeyValue(AsyncKeyValueProtocol, Protocol):
+    """A protocol for key-value store operations.
+
+    Includes basic operations: get, put, delete, ttl
+    Includes bulk operations: get_many, put_many, delete_many, ttl_many.
+    """


### PR DESCRIPTION
Added AsyncKeyValue protocol for key-value store operations including basic and bulk operations.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/strawgate/py-key-value/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

