### PR TITLE
Treat a vanished entry as a miss in FileTreeStore.get_entry

### DIFF
--- a/src/key_value/aio/stores/filetree/store.py
+++ b/src/key_value/aio/stores/filetree/store.py
@@ -270,7 +270,12 @@ class DiskCollectionInfo:
         if not await key_path.exists():
             return None
 
-        data_dict: dict[str, Any] = await read_file(file=key_path)
+        try:
+            data_dict: dict[str, Any] = await read_file(file=key_path)
+        except FileNotFoundError:
+            # Another actor removed the entry between the exists() check and the read.
+            # Report a miss, the same as delete_entry does when the file is already gone.
+            return None
 
         return self.serialization_adapter.load_dict(data=data_dict)
 

--- a/tests/stores/filetree/test_filetree.py
+++ b/tests/stores/filetree/test_filetree.py
@@ -60,6 +60,26 @@ class TestFileTreeStore(BaseStoreTests):
         assert await store.delete(collection="test", key="race_key") is False
         assert await store.get(collection="test", key="race_key") is None
 
+    async def test_get_returns_none_when_file_disappears_after_exists_check(
+        self,
+        store: FileTreeStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """get should report a miss when another actor removes the file mid-read."""
+        await store.put(collection="test", key="race_key", value={"data": "value"})
+
+        original_exists = AsyncPath.exists
+
+        async def exists_then_external_removal(path: AsyncPath) -> bool:
+            result = await original_exists(path)
+            if Path(path).name == "race_key.json":
+                Path(path).unlink()
+            return result
+
+        monkeypatch.setattr(AsyncPath, "exists", exists_then_external_removal)
+
+        assert await store.get(collection="test", key="race_key") is None
+
 
 class TestFileTreeStorePathTraversal:
     """Test suite for FileTreeStore path traversal security."""


### PR DESCRIPTION
Closes #366.

`get_entry` checks that the file exists and then opens it. If something deletes the entry in between, `read_file` raises `FileNotFoundError` and it reaches the caller.

This returns `None` instead. That is what `get` already returns when the file is gone at the `exists()` check, and what `delete_entry` does in the same class.

The test removes the file inside the `exists()` call, following `test_delete_returns_false_when_file_disappears_before_unlink`, so the interleaving is deterministic rather than timing-dependent.

Checks on Python 3.12: `ruff format` and `ruff check` clean, `basedpyright` 0 errors, and the two filetree race tests pass. Without the change in `store.py` the new test fails with `FileNotFoundError`.

Context for why this matters in practice is in #366: we hit it on FastMCP's `OAuthProxy`, where one-time-use refresh tokens are deleted as part of normal rotation, and the exception turned a cache miss the caller handles into an HTTP 500.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/strawgate/py-key-value/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

